### PR TITLE
docs: make README Quick Start runnable against 0.1.2

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -52,36 +52,44 @@
 ### 1. 把运行时嵌入到自己的应用
 
 ```bash
-pnpm add @melandlabs/opencontext @melandlabs/opencontext
+pnpm add @melandlabs/opencontext
 ```
 
-四动词 API 的 30 秒示例:
+记忆 API 的 30 秒示例:
 
 ```ts
-import { createMemoryStore } from "@melandlabs/opencontext";
+import { createMemoryStore, getRawMessageManager } from "@melandlabs/opencontext";
 
-const store = createMemoryStore({
-	db: { type: "sqlite-vec", path: "./memory.db" },
-	vector: { provider: "openai", model: "text-embedding-3-small" },
-});
+// 存储默认走 SQLite，路径由 MEMORY_STORE_DB_PATH 决定（默认 ./memory.db）。
+// 每次调用都会返回 awaitable 句柄。
+const store = await createMemoryStore();
+const messages = await getRawMessageManager();
 
-await store.remember({
-	content: "User prefers dark mode in all tools",
-	scope: "user:42",
-});
+// 一条消息就是一条事实：归属于某个用户的单段内容。
+// `messageId` 让重复摄取天然幂等。
+const now = Date.now();
+await messages.storeMessages([
+	{
+		messageId: "msg-1",
+		userId: "u-42",
+		content: "User prefers dark mode in all tools",
+		platform: "test",
+		botId: "bot-1",
+		timestamp: now,
+		createdAt: now,
+	},
+]);
 
-const hits = await store.recall({
+// 统一搜索会向 memory + insights + knowledge 三个来源扇出。
+// 未配置的来源只会发一条 warning —— 单后端部署完全没问题。
+const hits = await store.searchUnifiedMemory({
+	userId: "u-42",
 	query: "What does the user prefer?",
-	topK: 5,
+	limit: 5,
 });
-
-await store.improve({
-	target: hits[0].id,
-	kind: "supersedes",
-	evidence: "User toggled to light mode in settings on 2026-08-10",
-});
-
-await store.forget({ id: hits[0].id, reason: "superseded" });
+// hits.count    — 结果条数
+// hits.sources  — 真正被查询过的子索引
+// hits.warnings — 各来源的降级信息（例如缺少 embedder）
 ```
 
 ### 2. 从源码构建本 monorepo
@@ -140,28 +148,20 @@ pnpm test
 
 ## 常用使用模式
 
-### 四动词 API
+### 记忆 API
 
-`@melandlabs/opencontext` 暴露一个工厂函数与四个动词。这些动词是覆盖事实完整生命周期所需的最小集合 —— 其他一切都是实现细节。完整的配置矩阵与示例见 [`packages/memory-store/README.md`](./packages/memory-store/README.md)。
+`@melandlabs/opencontext` 暴露两个工厂调用加上一个扁平、小巧的搜索面。写入走 raw message manager,并天然按 `messageId` 幂等；读取会向 memory + insights + knowledge 扇出,未配置的来源优雅降级。完整的配置矩阵与示例见 [`packages/memory-store/README.md`](./packages/memory-store/README.md)。
 
-| 动词       | 用途                                                                                          |
-| ---------- | --------------------------------------------------------------------------------------------- |
-| `remember` | 摄取与重新摄取。在 `(scope, content-hash)` 上幂等。                                           |
-| `recall`   | 在语义、词法、图结构与时间近因子查询之上的统一搜索。                                          |
-| `improve`  | 追加 supersession / contradiction / merge 边。原节点永远不会被硬删除。                        |
-| `forget`   | 通过 `valid_until = now` 进行软删除。GDPR 的被遗忘权由一个带外(out-of-band)合规流程负责处理。 |
+| 符号                              | 用途                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `createMemoryStore(config?)`      | 引导存储。返回 `{ raw, search, getRawMessageManager, searchUnifiedMemory, … }`。                  |
+| `getRawMessageManager()`          | 拿到当前生效的 raw message manager（默认 SQLite，注册后端后切换 Postgres）。                       |
+| `manager.storeMessages(messages)` | 摄取事实。按 `messageId` 幂等。每行承载完整的 `RawMessage` 形态。                                |
+| `store.searchUnifiedMemory(opts)` | 在 memory + insights + knowledge 上的统一搜索,未配置的来源只发 warning。                          |
 
 ### 时序查询(时间旅行)
 
-上下文图中每个节点都有 `valid_from` 与 `valid_until` 字段。一次 recall 可以通过过滤 `valid_from ≤ t < valid_until` 来查询某个时间点的事实 —— 非常适合"用户上周二相信的是什么?"或"当前生效的偏好是哪条?"这类问题。
-
-```ts
-const asOf = await store.recall({
-	query: "user's preferred working hours",
-	scope: "user:42",
-	asOf: new Date("2026-08-01"),
-});
-```
+上下文图中每条事实都带 `valid_from` 与 `valid_until`,因此某个时间点的查询等价于"其有效区间覆盖了 `t` 的事实"。统一搜索 API 本身并未直接暴露时间点过滤 —— 时序访问住在更下一层,在 `@melandlabs/ai/memory-consolidation`(`graph-aware-query`)与 `@melandlabs/indexeddb/memory-graph-evolution` 里。as-of 查询请直接参考这两个包。
 
 ### MCP server
 
@@ -172,7 +172,7 @@ const asOf = await store.recall({
 `createUnifiedSearch(deps)` 允许你为每个来源独立接入搜索器。你省略的来源只会打印一条 warning —— 对只读部署或单后端栈来说完全没问题:
 
 ```ts
-import { createUnifiedSearch } from "@melandlabs/opencontext/unified-search";
+import { createUnifiedSearch } from "@melandlabs/opencontext";
 
 const search = createUnifiedSearch({
 	embedQuery: myEmbedder.embedQuery,
@@ -195,7 +195,7 @@ const { results, warnings } = await search.searchUnifiedMemory({
 
 | 关注点     | 后端                                                                                 |
 | ---------- | ------------------------------------------------------------------------------------ |
-| Raw 消息   | SQLite-vec(Tauri / 桌面)、Postgres(服务端 / daemon)、IndexedDB(浏览器)               |
+| Raw 消息   | SQLite-vec(默认,本地文件)、Postgres(服务端 / daemon,通过工厂注册)、IndexedDB(浏览器) |
 | 向量索引   | SQLite-vec(默认)、pgvector、Chroma、IndexedDB                                        |
 | Embeddings | OpenAI、Anthropic、Cohere,通过 `@melandlabs/opencontext/universal-embeddings` 走本地 |
 

--- a/README.md
+++ b/README.md
@@ -66,23 +66,38 @@ pnpm add @melandlabs/opencontext
 A 30-second example of the memory API:
 
 ```ts
-import { createMemoryStore } from "@melandlabs/opencontext";
+import { createMemoryStore, getRawMessageManager } from "@melandlabs/opencontext";
 
-const store = await createMemoryStore({
-	db: { type: "sqlite-vec", path: "./memory.db" },
-	vector: { provider: "openai", model: "text-embedding-3-small" },
-});
+// The store defaults to SQLite at MEMORY_STORE_DB_PATH (./memory.db by
+// default). Each call returns an awaitable handle.
+const store = await createMemoryStore();
+const messages = await getRawMessageManager();
 
-await store.raw.remember({
-	content: "User prefers dark mode in all tools",
-	scope: "user:42",
-});
+// A message is one fact: a single piece of content attributed to a user.
+// `messageId` makes the call idempotent across re-ingest.
+const now = Date.now();
+await messages.storeMessages([
+	{
+		messageId: "msg-1",
+		userId: "u-42",
+		content: "User prefers dark mode in all tools",
+		platform: "test",
+		botId: "bot-1",
+		timestamp: now,
+		createdAt: now,
+	},
+]);
 
-const hits = await store.searchRawMemorySemantically({
-	query: "What does the user prefer?",
+// Unified search fans out to memory + insights + knowledge. Sources you
+// haven't wired up just emit a warning — fine for a single-backend deploy.
+const hits = await store.searchUnifiedMemory({
 	userId: "u-42",
+	query: "What does the user prefer?",
 	limit: 5,
 });
+// hits.count    — number of results
+// hits.sources  — which sub-indexes were actually consulted
+// hits.warnings — per-source degradation (e.g. missing embedder)
 ```
 
 ### 2. Build this monorepo from source
@@ -144,33 +159,29 @@ See [`examples/README.md`](./examples/README.md) for the full walkthrough.
 
 ### The memory API
 
-`@melandlabs/opencontext` exposes one factory and four verbs. The
-verbs are the minimum set that covers the full lifecycle of a fact —
-everything else is implementation. See
+`@melandlabs/opencontext` exposes two factory calls plus a small,
+flat search surface. Writes go through the raw-message manager and
+remain idempotent on `messageId`; reads fan out to memory + insights +
+knowledge and degrade gracefully when a source is unconfigured. See
 [`packages/memory-store/README.md`](./packages/memory-store/README.md)
 for the full configuration matrix and recipes.
 
-| Verb       | Use it for                                                                                                  |
-| ---------- | ----------------------------------------------------------------------------------------------------------- |
-| `remember` | Ingest and re-ingest. Idempotent on `(scope, content-hash)`.                                                |
-| `recall`   | Unified search across semantic, lexical, graph, and recency sub-queries.                                    |
-| `improve`  | Append a supersession / contradiction / merge edge. The original node is never hard-deleted.                |
-| `forget`   | Soft-delete via `valid_until = now`. GDPR right-to-erasure is handled by an out-of-band compliance process. |
+| Symbol                            | Use it for                                                                              |
+| --------------------------------- | --------------------------------------------------------------------------------------- |
+| `createMemoryStore(config?)`      | Boot the store. Returns `{ raw, search, getRawMessageManager, searchUnifiedMemory, … }`. |
+| `getRawMessageManager()`          | Resolve the active raw-message manager (SQLite by default, Postgres when registered).   |
+| `manager.storeMessages(messages)` | Ingest facts. Idempotent on `messageId`. Each row carries the full `RawMessage` shape. |
+| `store.searchUnifiedMemory(opts)` | Unified search across memory + insights + knowledge; unconfigured sources emit warnings. |
 
 ### Temporal queries (time travel)
 
-Every node in the context graph has `valid_from` and `valid_until`
-fields. A recall can ask for facts as-of a particular timestamp by
-filtering `valid_from ≤ t < valid_until` — useful for "what did the
-user believe last Tuesday?" or "which preference is current?".
-
-```ts
-const asOf = await store.recall({
-	query: "user's preferred working hours",
-	scope: "user:42",
-	asOf: new Date("2026-08-01"),
-});
-```
+Every fact in the underlying context graph carries `valid_from` and
+`valid_until`, so an as-of query is "the facts whose validity
+interval covered `t`". The unified search API does not expose
+point-in-time filtering directly — temporal access lives one layer
+deeper, in `@melandlabs/ai/memory-consolidation` (`graph-aware-query`)
+and `@melandlabs/indexeddb/memory-graph-evolution`. See those
+packages for as-of recall.
 
 ### MCP server
 


### PR DESCRIPTION
## Summary

The Quick Start snippets in `README.md` and `README-zh.md` referenced an API that does not exist in `@melandlabs/opencontext`:

- `createMemoryStore({ db: { type, path }, vector: { provider, model } })` — wrong config shape (the real `MemoryStoreConfig` has neither `db` nor `vector` at the top level)
- `store.raw.remember({ content, scope })` — `RawMessageStore` only exposes `getManager` / `getBackend` / `isAvailable` / `close`
- `store.searchRawMemorySemantically({ query, userId, limit })` — real method is `searchUnifiedMemory`
- The Chinese README went further and advertised a `remember` / `recall` / `improve` / `forget` four-verb API that has never existed
- The Chinese README imported `createUnifiedSearch` from `"@melandlabs/opencontext/unified-search"` — the facade only exposes it from the root
- The Chinese README install command was duplicated: `pnpm add @melandlabs/opencontext @melandlabs/opencontext`
- The Chinese README's backend-selection table still listed "SQLite-vec (Tauri / 桌面)" — Tauri was removed in commit `1151f810`

## Verification

Built the corrected snippet from the English Quick Start into a standalone script and ran it against `@melandlabs/opencontext@0.1.2` from `registry.npmjs.org`:

```
ids: [ 1 ]
count: 0 sources: memory,insights,knowledge warnings: 3
```

Ingest works, unified search fans out to all three sources, unconfigured sources degrade to warnings instead of throwing — exactly the behaviour the corrected prose now describes.

Also re-ran the `examples/` suite end-to-end (130 OK · 2 SKIP · 0 FAIL) against the published 0.1.2 artifacts, confirming the corrected README points at the same surface the demos use.

## Test plan

- [ ] Spot-check the rendered Quick Start against the published 0.1.2 packages:
  ```bash
  mkdir -p /tmp/readme-check && cd /tmp/readme-check
  npm init -y >/dev/null && npm install @melandlabs/opencontext@0.1.2 >/dev/null
  # copy the snippet from README.md into a script and run it
  ```
- [ ] Verify the Chinese version with the same flow against `@melandlabs/opencontext@0.1.2`
- [ ] Confirm `pnpm test` still passes in the monorepo (no code changes — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)