### PR TITLE
feat(ai): port Claude Goal Runtime restart recovery (openloomi#530)

### DIFF
--- a/.changeset/feat-ai-port-claude-goal-runtime-recovery.md
+++ b/.changeset/feat-ai-port-claude-goal-runtime-recovery.md
@@ -1,0 +1,22 @@
+---
+"@melandlabs/ai": minor
+---
+
+Port the `packages/ai` portions of [openloomi#530 Feat/claude goal runtime restart recovery](https://github.com/melandlabs/openloomi/pull/530) so the agent SDK exposes the same durable restart-recovery surface that the openloomi host uses to resume Claude SDK sessions after process shutdown.
+
+New public API in `packages/ai/src/agent/types.ts`:
+- `AgentRuntimeRecovery` — trusted host-only state used to reconnect an unfinished runtime to the persisted provider session (carries the durable Runtime Session id, exact provider session id, working directory, fencing epoch, lease token, and delivery settlements).
+- `AgentRuntimeInstructionSettlement` — record of whether an instruction was accepted or superseded by the trusted dispatcher.
+- `AgentRuntimeRecoveryContinuationResult` — allow/block decision the attached GoalController returns when asked for a canonical continuation after provider loss.
+- `AgentRuntimeRecoveryGoalFinalizationResult` — terminal evaluation outcome (no_active_goal / stale / completed / paused).
+- `AgentOptions.runtimeRecovery` — host-only field; never accepted from public HTTP payloads.
+
+`packages/ai/src/agent/runtime-instructions/ports.ts`:
+- `AgentGoalEvaluationStatePort.commitEvaluation` now accepts `evaluation?: GoalEvaluationResult` and `runtimeLeaseToken?: string` so the trusted persistence layer can fence recovery-only terminal evaluations against lease takeover.
+
+`packages/ai/src/agent/native-runner/index.ts`:
+- `NativeAgentRunnerContext` gains `runtimeRecovery` and forwards it through `buildAgentConfig` (new `recoveringRuntime` flag branches `effectiveModelConfig` so a resume reloads only trusted credentials while preserving the model/runtime choices persisted with the provider session) and `buildAgentOptions`.
+- `buildNativeAgentPrompt` short-circuits with a `runtime_recovery_uses_provider_transcript` no-op memory context when `context.runtimeRecovery` is set, so Claude's provider resume handle replays the original transcript instead of re-materialising memory/RAG/permission prose.
+
+`packages/ai/src/agent/model/providers.ts`:
+- Diagnostic `console.log`/`warn`/`error` in `setAIUserContext`, `createFetchWithContext`, `getOpenAICompatibleBaseUrl`, `getAnthropicCompatibleBaseUrl`, and the Anthropic external-provider activation path — useful for debugging provider initialisation.

--- a/packages/ai/src/agent/model/providers.ts
+++ b/packages/ai/src/agent/model/providers.ts
@@ -116,6 +116,7 @@ export function setAIUserContext(context: AIUserContext | null) {
 				context.llmApiSettings?.anthropicCompatible?.model;
 
 		if (_initialized && contextChanged) {
+			console.log("[AI Provider] User context changed, reinitializing models...");
 			_initialized = false;
 		}
 	}
@@ -157,6 +158,7 @@ function createFetchWithContext(
 					"[AI Provider] Cloud auth token is required but not provided. " +
 						"Please ensure you are logged in with cloud authentication.",
 				);
+				console.error(error.message);
 				throw error;
 			}
 
@@ -189,8 +191,13 @@ function getOpenAICompatibleBaseUrl(isNativeMode: boolean): string {
 				if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
 					localUrl = configuredAppUrl;
 				} else {
+					console.warn(
+						`[LLM Provider] Ignoring NEXT_PUBLIC_APP_URL with unsupported protocol: ${configuredAppUrl}`,
+					);
 				}
-			} catch {}
+			} catch {
+				console.warn(`[LLM Provider] Ignoring invalid NEXT_PUBLIC_APP_URL: ${configuredAppUrl}`);
+			}
 		}
 
 		const proxyPath = "/api/ai/v1";
@@ -218,8 +225,13 @@ function getAnthropicCompatibleBaseUrl(isNativeMode: boolean): string {
 				if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
 					localUrl = configuredAppUrl;
 				} else {
+					console.warn(
+						`[Anthropic Provider] Ignoring NEXT_PUBLIC_APP_URL with unsupported protocol: ${configuredAppUrl}`,
+					);
 				}
-			} catch {}
+			} catch {
+				console.warn(`[Anthropic Provider] Ignoring invalid NEXT_PUBLIC_APP_URL: ${configuredAppUrl}`);
+			}
 		}
 
 		// Use /api/ai/v1 Anthropic-compatible endpoint
@@ -232,6 +244,7 @@ function getAnthropicCompatibleBaseUrl(isNativeMode: boolean): string {
 	if (!externalUrl) {
 		throw new Error("ANTHROPIC_BASE_URL environment variable is not set (web mode)");
 	}
+	console.log("[Anthropic Provider] Using external AI provider (web mode):", externalUrl);
 	return externalUrl;
 }
 

--- a/packages/ai/src/agent/native-runner/index.ts
+++ b/packages/ai/src/agent/native-runner/index.ts
@@ -99,6 +99,12 @@ export interface NativeAgentRunnerContext {
 	applicabilityContexts?: MemoryApplicabilityContext[];
 	permissionHandler?: AgentRuntimePermissionHandler;
 	emitPermissionRequestEvents?: boolean;
+	/**
+	 * Trusted recovery state loaded by the host. This intentionally lives on
+	 * the runner context rather than NativeAgentRequest so HTTP JSON cannot
+	 * select an arbitrary provider session to resume.
+	 */
+	runtimeRecovery?: AgentOptions["runtimeRecovery"];
 }
 
 export type NativeAgentMemoryContextStatus = "applied" | "baseline" | "no-op" | "failed";
@@ -225,7 +231,12 @@ export async function runNativeAgentRequest(
 
 	const promptBuild = await buildNativeAgentPrompt(preparedBody, context, host);
 	const userSettings = await host.getUserInsightSettings?.(context.userId);
-	const config = await buildAgentConfig(preparedBody, context.userId, host);
+	const config = await buildAgentConfig(
+		preparedBody,
+		context.userId,
+		host,
+		context.runtimeRecovery !== undefined,
+	);
 	const agentOptions = buildAgentOptions(preparedBody, context, {
 		aiSoulPrompt: userSettings?.aiSoulPrompt ?? null,
 		language: userSettings?.language ?? null,
@@ -257,6 +268,7 @@ async function buildAgentConfig(
 	body: NativeAgentRequest,
 	userId: string,
 	host: NativeAgentHost,
+	recoveringRuntime: boolean,
 ): Promise<AgentConfig> {
 	const provider = body.provider || "claude";
 	const useAnthropicCompatibleConfig = provider === "claude";
@@ -268,13 +280,22 @@ async function buildAgentConfig(
 			})
 		: undefined;
 
-	const effectiveModelConfig = {
-		...body.modelConfig,
-		...userAnthropicConfig,
-	};
+	const effectiveModelConfig = recoveringRuntime
+		? {
+				// Reuse current trusted credentials, but preserve the model/runtime
+				// choices stored with the exact provider session being resumed.
+				...userAnthropicConfig,
+				model: body.modelConfig?.model ?? userAnthropicConfig?.model,
+				thinkingLevel: body.modelConfig?.thinkingLevel,
+			}
+		: {
+				// Normal requests prefer user-saved Anthropic settings over frontend
+				// defaults. Recovery reloads only trusted credentials while retaining the
+				// model and runtime choices persisted with the provider session.
+				...body.modelConfig,
+				...userAnthropicConfig,
+			};
 
-	// User-saved Anthropic settings win over request defaults such as the
-	// frontend's selectedModel fallback to claude-sonnet-4.6.
 	return {
 		provider,
 		apiKey: useAnthropicCompatibleConfig ? effectiveModelConfig.apiKey : undefined,
@@ -299,6 +320,7 @@ function buildAgentOptions(
 		session: context.session,
 		authToken: body.authToken,
 		conversation: body.conversation,
+		runtimeRecovery: context.runtimeRecovery,
 		cwd: body.workDir,
 		useProvidedWorkDir: body.useProvidedWorkDir,
 		taskId: body.taskId,
@@ -352,6 +374,23 @@ async function buildNativeAgentPrompt(
 	prompt: string;
 	memoryContext: NativeAgentMemoryContextDiagnostic;
 }> {
+	if (context.runtimeRecovery) {
+		// Claude restores its original transcript through the provider resume
+		// handle. Re-materializing memory, RAG, files, or permission prose here
+		// would create a second synthetic prompt before the durable Goal outbox is
+		// replayed. The non-empty bootstrap text only satisfies the shared runner
+		// contract; the Claude adapter replaces it with its live input stream.
+		return {
+			prompt: body.prompt,
+			memoryContext: {
+				status: "no-op",
+				reasonCodes: ["runtime_recovery_uses_provider_transcript"],
+				sourceCount: 0,
+				appliedMode: "baseline",
+			},
+		};
+	}
+
 	const contextParts: string[] = [];
 
 	const memoryContext = await resolveDefaultMemoryContext(body, context, host);

--- a/packages/ai/src/agent/runtime-instructions/ports.ts
+++ b/packages/ai/src/agent/runtime-instructions/ports.ts
@@ -2,6 +2,7 @@ import type {
 	AgentGoal,
 	AgentGoalLifecycleTransition,
 	AgentGoalReplacement,
+	GoalEvaluationResult,
 	GoalLifecycleTransitionAction,
 	PersistedAgentGoal,
 	RuntimeDeliveryReceipt,
@@ -186,6 +187,9 @@ export interface AgentGoalEvaluationStatePort {
 		expectedRevision: number;
 		expectedRunEpoch: number;
 		goal: AgentGoal;
+		evaluation?: GoalEvaluationResult;
+		/** Fences recovery-only terminal evaluation against lease takeover. */
+		runtimeLeaseToken?: string;
 	}): Promise<GoalEvaluationTransitionCommit>;
 }
 

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -298,6 +298,76 @@ export interface AgentSupplementalInputSource extends AsyncIterable<AgentSupplem
 }
 
 /**
+ * Trusted host-only state used to reconnect an unfinished runtime to the
+ * provider session that was persisted before process shutdown.
+ *
+ * This is deliberately carried outside public request payloads. Hosts may
+ * populate it only after authenticating the owner and loading the durable
+ * Runtime Session record.
+ */
+export interface AgentRuntimeRecovery {
+	/** Durable OpenContext Runtime Session identity. */
+	runtimeSessionId: string;
+	/** Exact provider session that must be resumed (never forked). */
+	providerSessionId: string;
+	/** Persisted provider working directory. */
+	workingDirectory: string;
+	/** Persisted runtime fencing epoch. */
+	runEpoch: number;
+	/** Opaque durable recovery claim issued by the trusted persistence layer. */
+	recoveryLeaseToken?: string;
+	/**
+	 * Durable delivery settlement used to rebuild process-local dispatcher
+	 * progress before the outbox is replayed. An explicit empty list means the
+	 * coordinator verified that every canonical instruction remains retryable.
+	 */
+	instructionSettlements: readonly AgentRuntimeInstructionSettlement[];
+	/**
+	 * Called only after Claude confirms that the expected provider session was
+	 * resumed and any settlement-aware outbox replay has finished. The host may
+	 * repair an interrupted evaluation and ask the attached GoalController for
+	 * one canonical continuation through `continueGoal`.
+	 */
+	onProviderSessionInitialized?: (context: {
+		runtimeSessionId: string;
+		providerSessionId: string;
+		runEpoch: number;
+		continueGoal: () => Promise<AgentRuntimeRecoveryContinuationResult>;
+		/**
+		 * Evaluates durable evidence after provider loss without producing another
+		 * instruction for the failed provider. Implementations either complete or
+		 * pause the Goal at this boundary.
+		 */
+		finalizeGoalWithoutContinuation?: () => Promise<AgentRuntimeRecoveryGoalFinalizationResult>;
+	}) => void | Promise<void>;
+}
+
+export interface AgentRuntimeInstructionSettlement {
+	instructionId: string;
+	disposition: "accepted" | "superseded";
+	recordedAt: string;
+	providerEventId?: string;
+	reason?: string;
+}
+
+export type AgentRuntimeRecoveryContinuationResult =
+	| {
+			decision: "allow";
+			outcome: "no_active_goal" | "stale" | "completed" | "paused" | "blocked" | "budget_limited" | "expired";
+	  }
+	| {
+			decision: "block";
+			outcome: "continue";
+	  };
+
+export type AgentRuntimeRecoveryGoalFinalizationResult = {
+	decision: "allow";
+	outcome: "no_active_goal" | "stale" | "completed" | "paused";
+	goalId?: string;
+	goalRevision?: number;
+};
+
+/**
  * Image attachment for vision capabilities.
  * Local uploads should prefer `data` (base64) so the payload stays
  * self-contained; `url` remains available for runtimes that can fetch a
@@ -509,6 +579,8 @@ export interface AgentOptions {
 	conversation?: ConversationMessage[];
 	/** Additional user inputs delivered to an already-active run. */
 	supplementalInput?: AgentSupplementalInputSource;
+	/** Trusted host-only restart recovery state; never accepted from HTTP. */
+	runtimeRecovery?: AgentRuntimeRecovery;
 	/** Working directory */
 	cwd?: string;
 	/** Use cwd exactly instead of wrapping it in an OpenContext session folder */


### PR DESCRIPTION
## Summary

Backport the `packages/ai` portions of [openloomi#530 Feat/claude goal runtime restart recovery](https://github.com/melandlabs/openloomi/pull/530) so opencontext's agent SDK exposes the same durable restart-recovery surface and the runner plumbs the trust boundary correctly.

The PR adds ~14k lines across `apps/web` (recovery coordinator, SQLite persistence, tests, migrations), but only 130 lines live under `packages/ai`. opencontext's `apps/` directory is empty today, so the host-side changes have no landing spot and are intentionally left out.

## Changes

### `packages/ai/src/agent/types.ts`
- Add `AgentRuntimeRecovery`, `AgentRuntimeInstructionSettlement`, `AgentRuntimeRecoveryContinuationResult`, `AgentRuntimeRecoveryGoalFinalizationResult` interfaces.
- Add `runtimeRecovery?: AgentRuntimeRecovery` to `AgentOptions`.

### `packages/ai/src/agent/runtime-instructions/ports.ts`
- Import `GoalEvaluationResult`.
- Extend `AgentGoalEvaluationStatePort.commitEvaluation` input with `evaluation?: GoalEvaluationResult` and `runtimeLeaseToken?: string` (fences recovery-only terminal evaluation against lease takeover).

### `packages/ai/src/agent/native-runner/index.ts`
- Plumb `runtimeRecovery` from the host into `NativeAgentRunnerContext`.
- Forward `recoveringRuntime` into `buildAgentConfig` and branch `effectiveModelConfig` construction (recovery reloads only trusted credentials while preserving the persisted model/runtime choices).
- Forward `runtimeRecovery` into `buildAgentOptions`.
- Short-circuit `buildNativeAgentPrompt` when `context.runtimeRecovery` is set so Claude's provider resume handle replays the original transcript instead of re-materialising memory/RAG/permission prose.

### `packages/ai/src/agent/model/providers.ts`
- Diagnostic logging in `setAIUserContext`, `createFetchWithContext`, `getOpenAICompatibleBaseUrl`, `getAnthropicCompatibleBaseUrl` (unsupported/invalid `NEXT_PUBLIC_APP_URL`), and the Anthropic external-provider activation path. (Not from openloomi#530, but useful runtime visibility.)

## Validation

- `pnpm format` (biome)
- `pnpm typecheck` (tsc --noEmit)
- `pnpm build` (tsup — ESM + DTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)