### PR TITLE
fix(dsh-opencontext): add repository metadata

### DIFF
--- a/plugins/dsh-opencontext/package.json
+++ b/plugins/dsh-opencontext/package.json
@@ -1,7 +1,12 @@
 {
 	"name": "dsh-opencontext",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "DeepSeek Harness plugin that wires DSH agents to OpenContext for durable memory + retrieval-augmented context.",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/melandlabs/opencontext.git",
+		"directory": "plugins/dsh-opencontext"
+	},
 	"type": "module",
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `dsh-opencontext` from `0.3.0` to `0.3.1`.
- Add canonical GitHub repository and plugin subdirectory metadata to the package manifest.

## Motivation
The package currently has no repository metadata in its source manifest or npm metadata, so `awesome-dsh-plugin/dsh-market` cannot reliably associate the npm package with its canonical GitHub subdirectory.

## Verification
- `pnpm install --ignore-workspace --frozen-lockfile` completed; pnpm warned that Node `v22.14.0` is below the package engine requirement `^22.19.0 || >=24.0.0`.
- A manifest assertion passed for the version and repository metadata.
- `pnpm pack --config.ignore-scripts=true` succeeded, and the packed `package/package.json` contains the expected version and repository metadata.
- `git diff --check` passed.
- `pnpm check` does not fully pass in this environment: typecheck/build report three existing `src/knowledge-store.ts` TypeScript errors, and tests pass 113/116 with three `better-sqlite3` native-binding failures. These failures are outside this package-metadata-only diff.

## Release note
After this PR is merged, a maintainer still needs to publish `dsh-opencontext@0.3.1` to npm.
