### PR TITLE
feat(memory-store): expose LLM reasoning over HTTP and MCP daemons

### DIFF
--- a/docs/tutorials/03-advanced-usage.md
+++ b/docs/tutorials/03-advanced-usage.md
@@ -367,6 +367,82 @@ const adHoc = await store.search({
 
 Resolution order at lookup time is: per-call `reasoningStrategy` → store-level `unified.reasoning.defaultStrategy` → `"none"`. Set `defaultStrategy: "none"` explicitly if you want to opt out of a default that another module turned on.
 
+### Exposing Reasoning Over HTTP and MCP
+
+The same reasoning layer is reachable from the `@melandlabs/memory-store` CLI daemons — no host-side wiring required. Add `--reasoning` and the bin reads `OPENCONTEXT_LLM_API_KEY` / `OPENCONTEXT_LLM_BASE_URL` / `OPENCONTEXT_LLM_MODEL` from your environment and wires `queryRewriter` + `iterativePlanner` into the `unified` deps.
+
+Reasoning is **off by default** — the flag is opt-in. If `OPENCONTEXT_LLM_API_KEY` is missing, the daemon refuses to start with a clear remediation message rather than starting in a degraded state.
+
+```bash
+# HTTP daemon (port 7421 by default)
+opencontext-memory-http \
+  --reasoning \
+  --embedding-provider local \
+  --memory-backend sqlite-vec
+
+# MCP daemon (stdio transport)
+opencontext-memory-mcp \
+  --reasoning \
+  --embedding-provider local \
+  --memory-backend sqlite-vec
+```
+
+Once the daemon is running, the existing endpoints / tools accept a `reasoningStrategy` field that selects which strategy to run per call:
+
+```bash
+# HTTP — POST /v1/search
+curl -X POST http://127.0.0.1:7421/v1/search \
+  -H 'content-type: application/json' \
+  -d '{
+    "userId": "user-42",
+    "query": "What outdoor activities has the user mentioned?",
+    "reasoningStrategy": "iterative",
+    "limit": 5
+  }'
+```
+
+```jsonc
+// MCP — memory.search tool
+{
+  "userId": "user-42",
+  "query": "What does the user enjoy doing on weekends?",
+  "reasoningStrategy": "rewrite", // or "iterative"
+  "limit": 5
+}
+```
+
+The response carries a `reasoning` block so callers can observe what ran:
+
+```jsonc
+{
+  "query": "What outdoor activities has the user mentioned?",
+  "count": 2,
+  "results": [/* … */],
+  "reasoning": {
+    "strategy": "iterative",
+    "iterations": 4,
+    "evidenceCount": 6,
+    "degraded": false
+  },
+  "warnings": []
+}
+```
+
+If the daemon was started **without** `--reasoning`, calls with `reasoningStrategy: "rewrite" | "iterative"` still succeed — the response includes a `memory_*_not_configured` warning and falls back to the default hybrid search. Opting out is the safe default for low-latency / no-LLM deployments; opt in per daemon when you want reasoning available.
+
+Additional flags and env vars for fine-grained control:
+
+| Flag / env                              | Default                                          | Purpose                                       |
+| --------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| `--reasoning` / `REASONING=1`           | off                                              | Enable the LLM reasoning layer.               |
+| `--no-reasoning`                        | —                                                | Force-disable even when `REASONING=1` is set. |
+| `--reasoning-base-url` / `OPENCONTEXT_LLM_BASE_URL` | `https://openrouter.ai/api/v1`        | OpenAI-compatible base URL.                   |
+| `--reasoning-model` / `OPENCONTEXT_LLM_MODEL`        | `openai/gpt-4o-mini`                | Reasoning LLM model identifier.               |
+| `--reasoning-timeout-ms` / `OPENCONTEXT_LLM_TIMEOUT_MS` | `30000`                              | Per-request timeout.                          |
+| `OPENCONTEXT_LLM_API_KEY`               | _required when `--reasoning`_                    | Bearer token for the reasoning LLM.           |
+
+See `opencontext-memory-http --help` / `opencontext-memory-mcp --help` for the full flag surface.
+
 
 ### Date-Range Filtering
 

--- a/packages/memory-store/CHANGELOG.md
+++ b/packages/memory-store/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @melandlabs/memory-store
 
+## Unreleased
+
+### Patch Changes
+
+- `cli-shared.ts`: add `--reasoning` / `--no-reasoning` /
+  `--reasoning-base-url` / `--reasoning-model` / `--reasoning-timeout-ms`
+  flags (and `REASONING` / `OPENCONTEXT_LLM_BASE_URL` / `OPENCONTEXT_LLM_MODEL`
+  / `OPENCONTEXT_LLM_TIMEOUT_MS` env equivalents). When `--reasoning` is set,
+  `buildUnified()` wires `unified.reasoning.{queryRewriter, iterativePlanner}`
+  using a raw `fetch` against the OpenAI-compatible chat completions endpoint
+  (no `ai` SDK dependency). Honors the `OPENCONTEXT_LLM_API_KEY` env var that
+  the `@melandlabs/opencontext` facade already documents — existing `.env`
+  files work as-is. Reasoning stays off by default; if `OPENCONTEXT_LLM_API_KEY`
+  is missing the bin refuses to start with a clear remediation message.
+
+- `http.ts`: `POST /v1/search` body now plumbs `reasoningStrategy` through
+  to `SearchInput.reasoningStrategy` (previously the field was silently
+  dropped, so per-call reasoning had no effect over HTTP).
+
+- `mcp.ts`: `memory.search` tool schema gains `reasoningStrategy`
+  (`"none" | "rewrite" | "iterative"`, optional), and the handler plumbs
+  it through to `SearchInput.reasoningStrategy`. The MCP daemon now mirrors
+  the SDK surface for reasoning strategies.
+
+- `cli-http.ts` / `cli-mcp.ts`: `--help` output documents the new reasoning
+  flags and includes an end-to-end `--reasoning` example for both daemons.
+
 ## 1.1.6
 
 ### Patch Changes

--- a/packages/memory-store/README.md
+++ b/packages/memory-store/README.md
@@ -49,6 +49,7 @@ endpoints:
 | Read a single `RawMessage` | `manager.getMessageById(id)` | `GET /v1/raw-messages/:id?userId=…` | `memory.getRawMessage` |
 | Persist a `RawMessage` | `manager.storeMessages([…])` | `POST /v1/raw-messages` | `memory.writeRawMessage` |
 | Read-only LLM synthesis over evidence | `store.search({ ...input, synthesize: true })` | `POST /v1/search` (set `synthesize: true`) | `memory.search` (set `synthesize: true`) |
+| LLM reasoning layer (query-rewrite / iterative planner) | `store.search({ ...input, reasoningStrategy: "rewrite" \| "iterative" })` | `POST /v1/search` (set `reasoningStrategy`) | `memory.search` (set `reasoningStrategy`) |
 | **Agentic write-back** (gather → plan → vet → persist) | `store.consolidate(input)` | `POST /v1/consolidate:apply` | `memory.consolidate` |
 | Health probe | — | `GET /health` | `memory.health` |
 
@@ -66,6 +67,39 @@ CLI bins ship with the package:
 opencontext-memory-http --port 7421 --host 127.0.0.1
 opencontext-memory-mcp
 ```
+
+Both bins accept the same `--embedding-provider` / `--*-backend` flag surface
+(see `--help` for the full list). Reasoning is **off by default** — opt in
+with `--reasoning`, which reads `OPENCONTEXT_LLM_API_KEY` /
+`OPENCONTEXT_LLM_BASE_URL` / `OPENCONTEXT_LLM_MODEL` from the environment:
+
+```bash
+# HTTP daemon with local embeddings + sqlite-vec memory + LLM reasoning
+opencontext-memory-http \
+  --reasoning \
+  --embedding-provider local \
+  --memory-backend sqlite-vec
+
+# Same wiring, stdio MCP daemon (Claude Desktop / Cursor / Claude Code)
+opencontext-memory-mcp \
+  --reasoning \
+  --embedding-provider local \
+  --memory-backend sqlite-vec
+```
+
+Once the daemon is up, `POST /v1/search` (HTTP) and `memory.search` (MCP)
+honor a `reasoningStrategy` field:
+
+| `reasoningStrategy` | What runs |
+|---|---|
+| `"none"` (default) | Plain hybrid search — no LLM call. |
+| `"rewrite"`         | One LLM call rephrases the query into a first-person memory-check question, then the normal hybrid search runs. |
+| `"iterative"`       | An LLM planner searches, notes evidence, searches again — multi-hop / temporal questions benefit most. |
+
+The response carries a `reasoning` block (`{ strategy, iterations,
+evidenceCount, degraded }`) so callers can observe what ran. See
+[Recipe 9](#9-http-daemon) and [Recipe 10](#10-mcp-daemon) below for the
+programmatic equivalents.
 
 ## Configuration matrix
 
@@ -85,6 +119,10 @@ opencontext-memory-mcp
 | `unified.searchSummaries`                              | optional                        | L1/L2/L3 summary recall (used by `reflect`)               |
 | `unified.peerScopeCheck`                              | optional                        | host check that gates `peerFilter` narrowing              |
 | `unified.reranker`                                    | optional                        | cross-encoder / learned ranker applied after merge        |
+| `unified.reasoning.queryRewriter`                     | optional, enables `"rewrite"`   | turns third-person questions into first-person memory checks before embedding |
+| `unified.reasoning.iterativePlanner`                  | optional, enables `"iterative"` | LLM-driven multi-step recall; planner calls back into `search` and `note` actions |
+| `unified.reasoning.complete`                          | optional, enables `synthesize`  | single-turn LLM callback for evidence synthesis (`reflect`) |
+| `unified.reasoning.defaultStrategy`                   | optional                        | `"none" \| "rewrite" \| "iterative"` — applied when callers omit `reasoningStrategy` |
 | `graphStore`                                          | optional                        | `MemoryGraphStoreWithOperationHistory`; powers `consolidate` |
 | `storage`                                             | optional                        | `MemoryStorageAdapter` for `deprecateRecords` writes      |
 | `logger`                                              | optional                        | `console`-shaped logger; defaults to `console`            |
@@ -396,15 +434,58 @@ Or run the CLI:
 MEMORY_HTTP_HOST=0.0.0.0 MEMORY_HTTP_PORT=7421 opencontext-memory-http
 ```
 
+To opt into LLM reasoning from the CLI, add `--reasoning`. The bin reads
+`OPENCONTEXT_LLM_API_KEY` / `OPENCONTEXT_LLM_BASE_URL` / `OPENCONTEXT_LLM_MODEL`
+from the environment — your existing `.env` works as-is:
+
+```bash
+OPENCONTEXT_LLM_API_KEY=sk-... \
+  opencontext-memory-http \
+    --reasoning \
+    --embedding-provider local \
+    --memory-backend sqlite-vec
+```
+
+Programmatically, wire the reasoning layer via `unified.reasoning`:
+
+```ts
+import { startHttpServer } from "@melandlabs/memory-store/http";
+import {
+	createUserVoiceRewriter,
+	createIterativeRecallPlanner,
+} from "@melandlabs/memory-store";
+
+const complete = async (prompt: string) => callMyLlm(prompt); // any OpenAI-compatible chat completions endpoint
+
+const { url, stop } = await startHttpServer({
+	port: 7421,
+	host: "127.0.0.1",
+	unified: {
+		embedQuery: myEmbedder,
+		reasoning: {
+			queryRewriter: createUserVoiceRewriter({ complete }),
+			iterativePlanner: createIterativeRecallPlanner({ complete }),
+			// defaultStrategy: "iterative",  // uncomment to enable by default
+		},
+	},
+});
+```
+
 Endpoints:
 
 | Method + path                          | Body                                                                                                |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `GET  /health`                         | —                                                                                                   |
-| `POST /v1/search`                      | `{ userId, query, limit?, threshold?, sources?, botIds?, documentIds?, factTypes?, synthesize? }`    |
+| `POST /v1/search`                      | `{ userId, query, limit?, threshold?, sources?, botIds?, documentIds?, factTypes?, synthesize?, reasoningStrategy? }` |
 | `POST /v1/consolidate:apply`           | `{ userId, query, ownerScope, tiers?, limit?, threshold?, dryRun?, expectedVersion?, llmPlanReview? }` |
 | `POST /v1/raw-messages`                | `{ userId, messages: RawMessage[] }`                                                                |
 | `GET  /v1/raw-messages/:id?userId=...` | —                                                                                                   |
+
+`reasoningStrategy` accepts `"none"` (default — no LLM call),
+`"rewrite"` (single LLM rephrase), or `"iterative"` (multi-step planner).
+When set and the server is not wired with the corresponding provider, the
+response includes a `*_not_configured` warning and the search falls back to
+the default path.
 
 For container / LAN deployment, put it behind a reverse proxy:
 
@@ -422,15 +503,25 @@ location /memory/ {
 opencontext-memory-mcp
 ```
 
+To expose LLM reasoning to MCP clients (Claude Desktop, Cursor, Claude Code):
+
+```bash
+OPENCONTEXT_LLM_API_KEY=sk-... \
+  opencontext-memory-mcp \
+    --reasoning \
+    --embedding-provider local \
+    --memory-backend sqlite-vec
+```
+
 Tools exposed over stdio:
 
-| Tool                     | Required args                                                                                                                       |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `memory.health`          | —                                                                                                                                   |
-| `memory.search`          | `userId`, `query`, optional `limit`, `threshold`, `sources`, `botIds`, `documentIds`, `factTypes`, `synthesize`, `tiers`           |
-| `memory.writeRawMessage` | `userId`, `message: { role, content, platform?, botId?, factType?, peer?, ... }`                                                    |
-| `memory.getRawMessage`   | `userId`, `messageId`                                                                                                               |
-| `memory.consolidate`     | `userId`, `query`, `ownerScope`, optional `tiers`, `dryRun`, `expectedVersion`, `llmPlanReview`, `plan`                             |
+| Tool                     | Required args                                                                                                                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memory.health`          | —                                                                                                                                                                                              |
+| `memory.search`          | `userId`, `query`, optional `limit`, `threshold`, `sources`, `botIds`, `documentIds`, `factTypes`, `synthesize`, `tiers`, **`reasoningStrategy`** (`"none" \| "rewrite" \| "iterative"`)        |
+| `memory.writeRawMessage` | `userId`, `message: { role, content, platform?, botId?, factType?, peer?, ... }`                                                                                                               |
+| `memory.getRawMessage`   | `userId`, `messageId`                                                                                                                                                                          |
+| `memory.consolidate`     | `userId`, `query`, `ownerScope`, optional `tiers`, `dryRun`, `expectedVersion`, `llmPlanReview`, `plan`                                                                                        |
 
 #### Claude Desktop (`claude_desktop_config.json`)
 

--- a/packages/memory-store/src/http.ts
+++ b/packages/memory-store/src/http.ts
@@ -200,6 +200,10 @@ export async function startHttpServer(options: StartHttpServerOptions = {}): Pro
 			authToken: typeof body.authToken === "string" ? body.authToken : undefined,
 			dateFrom: typeof body.dateFrom === "string" ? body.dateFrom : undefined,
 			dateTo: typeof body.dateTo === "string" ? body.dateTo : undefined,
+			reasoningStrategy:
+				body.reasoningStrategy === "rewrite" || body.reasoningStrategy === "iterative"
+					? body.reasoningStrategy
+					: undefined,
 			...(wantsSynthesis
 				? {
 						synthesize: {

--- a/packages/memory-store/src/mcp.ts
+++ b/packages/memory-store/src/mcp.ts
@@ -122,6 +122,12 @@ export async function startMcpServer(options: StartMcpServerOptions = {}): Promi
 			.describe(
 				"Per-tier evidence scope for synthesis. Default: ['summary','raw','insight','knowledge']. Ignored when `synthesize` is falsy.",
 			),
+		reasoningStrategy: z
+			.enum(["none", "rewrite", "iterative"])
+			.optional()
+			.describe(
+				"LLM reasoning strategy. `rewrite` rephrases the query before embedding; `iterative` runs a planner that searches, notes evidence, and searches again. Requires `unified.reasoning.{queryRewriter,iterativePlanner}` to be wired into the server.",
+			),
 		synthesize: z
 			.union([z.boolean(), z.object({ responseSchema: z.record(z.string(), z.unknown()).optional() })])
 			.optional()
@@ -212,6 +218,7 @@ export async function startMcpServer(options: StartMcpServerOptions = {}): Promi
 				query: string;
 				sources?: ("memory" | "insights" | "knowledge")[];
 				tiers?: Array<"summary" | "raw" | "insight" | "knowledge">;
+				reasoningStrategy?: "none" | "rewrite" | "iterative";
 				synthesize?: boolean | { responseSchema?: Record<string, unknown> };
 				responseSchema?: Record<string, unknown>;
 				limit?: number;
@@ -239,6 +246,10 @@ export async function startMcpServer(options: StartMcpServerOptions = {}): Promi
 				documentIds: a.documentIds,
 				authToken: a.authToken,
 				includeArchivedInsights: a.includeArchivedInsights,
+				reasoningStrategy:
+					a.reasoningStrategy === "rewrite" || a.reasoningStrategy === "iterative"
+						? a.reasoningStrategy
+						: undefined,
 				...(a.tiers ? { tiers: a.tiers } : {}),
 				...(wantsSynthesis
 					? {

--- a/packages/memory-store/src/server/cli-http.ts
+++ b/packages/memory-store/src/server/cli-http.ts
@@ -97,6 +97,15 @@ Examples:
     --embedding-provider local \\
     --memory-backend sqlite-vec
 
+  # Same as above + LLM reasoning (query-rewriter + iterative planner).
+  # Reads OPENCONTEXT_LLM_API_KEY / OPENCONTEXT_LLM_BASE_URL /
+  # OPENCONTEXT_LLM_MODEL from the environment so .env Just Works.
+  # After this, POST /v1/search honors body.reasoningStrategy: rewrite|iterative.
+  opencontext-memory-http \\
+    --embedding-provider local \\
+    --memory-backend sqlite-vec \\
+    --reasoning
+
   # Wire everything via a running Chroma server
   opencontext-memory-http \\
     --embedding-provider openrouter \\

--- a/packages/memory-store/src/server/cli-mcp.ts
+++ b/packages/memory-store/src/server/cli-mcp.ts
@@ -84,6 +84,14 @@ Examples:
     --embedding-provider local \\
     --memory-backend sqlite-vec
 
+  # Same as above + LLM reasoning (memory.search honors
+  # reasoningStrategy: 'rewrite' | 'iterative'). Reads OPENCONTEXT_LLM_*
+  # from the environment so .env Just Works.
+  opencontext-memory-mcp \\
+    --embedding-provider local \\
+    --memory-backend sqlite-vec \\
+    --reasoning
+
   # Wire everything via a running Chroma server
   opencontext-memory-mcp \\
     --embedding-provider openrouter \\

--- a/packages/memory-store/src/server/cli-shared.ts
+++ b/packages/memory-store/src/server/cli-shared.ts
@@ -16,6 +16,8 @@
  */
 
 import type { UnifiedSearchDeps } from "../config";
+import { createIterativeRecallPlanner } from "../search/iterative-recall";
+import { createUserVoiceRewriter } from "../search/query-rewriter";
 import { createRawMessageStore } from "../storage/raw-message-store";
 import { isInsightSQLiteVecEnabled, searchInsightsWithSQLiteVec } from "../storage/sqlite-vector-index";
 
@@ -28,6 +30,20 @@ export interface UnifiedArgs {
 	insightsCollection: string;
 	knowledgeBackend: "chroma" | "none";
 	knowledgeCollection: string;
+	/**
+	 * Wire `unified.reasoning.{queryRewriter, iterativePlanner}` from the
+	 * `OPENCONTEXT_LLM_*` env vars. When false, reasoning providers stay
+	 * unset and `POST /v1/search` / `memory.search` requests with
+	 * `reasoningStrategy: "rewrite" | "iterative"` will surface a
+	 * `_not_configured` warning and fall back to the default search path.
+	 */
+	reasoning: boolean;
+	/** OpenAI-compatible base URL the reasoning LLM is served from. */
+	reasoningBaseUrl?: string;
+	/** Reasoning LLM model identifier. */
+	reasoningModel?: string;
+	/** Request timeout for reasoning LLM calls (ms). @default 30000 */
+	reasoningTimeoutMs?: number;
 }
 
 interface AiRagModules {
@@ -79,6 +95,12 @@ export function parseUnifiedArgs(argv: string[]): UnifiedArgs {
 		insightsCollection: env.INSIGHTS_COLLECTION ?? "opencontext_insights",
 		knowledgeBackend: (env.KNOWLEDGE_BACKEND as UnifiedArgs["knowledgeBackend"] | undefined) ?? "none",
 		knowledgeCollection: env.KNOWLEDGE_COLLECTION ?? "opencontext_knowledge",
+		reasoning: env.REASONING === "1" || env.REASONING === "true",
+		reasoningBaseUrl: env.OPENCONTEXT_LLM_BASE_URL,
+		reasoningModel: env.OPENCONTEXT_LLM_MODEL,
+		reasoningTimeoutMs: env.OPENCONTEXT_LLM_TIMEOUT_MS
+			? Number.parseInt(env.OPENCONTEXT_LLM_TIMEOUT_MS, 10)
+			: undefined,
 	};
 	for (let i = 0; i < argv.length; i += 1) {
 		const arg = argv[i];
@@ -112,6 +134,21 @@ export function parseUnifiedArgs(argv: string[]): UnifiedArgs {
 				break;
 			case "--knowledge-collection":
 				args.knowledgeCollection = takeValue();
+				break;
+			case "--reasoning":
+				args.reasoning = true;
+				break;
+			case "--no-reasoning":
+				args.reasoning = false;
+				break;
+			case "--reasoning-base-url":
+				args.reasoningBaseUrl = takeValue();
+				break;
+			case "--reasoning-model":
+				args.reasoningModel = takeValue();
+				break;
+			case "--reasoning-timeout-ms":
+				args.reasoningTimeoutMs = Number.parseInt(takeValue(), 10);
 				break;
 		}
 	}
@@ -311,6 +348,64 @@ export async function buildUnified(args: UnifiedArgs): Promise<UnifiedSearchDeps
 		log(`knowledge backend wired via chroma (collection=${args.knowledgeCollection})`);
 	}
 
+	// ── 5. Wire the reasoning providers (query rewriter + iterative
+	//      planner). Off by default — hosts opt in via `--reasoning` or
+	//      `REASONING=1`. Backed by the same OPENCONTEXT_LLM_* env vars the
+	//      `@melandlabs/opencontext/memory-reasoning` helper uses, so the
+	//      .env the user already has for the facade CLI is reused as-is.
+	if (args.reasoning) {
+		const apiKey = process.env.OPENCONTEXT_LLM_API_KEY;
+		if (!apiKey) {
+			throw new Error(
+				"--reasoning requires OPENCONTEXT_LLM_API_KEY (and ideally OPENCONTEXT_LLM_BASE_URL / OPENCONTEXT_LLM_MODEL) in the environment",
+			);
+		}
+		const baseUrl =
+			args.reasoningBaseUrl ?? process.env.OPENCONTEXT_LLM_BASE_URL ?? "https://openrouter.ai/api/v1";
+		const model = args.reasoningModel ?? process.env.OPENCONTEXT_LLM_MODEL ?? "openai/gpt-4o-mini";
+		const timeoutMs = args.reasoningTimeoutMs ?? 30_000;
+
+		const complete = async (prompt: string): Promise<string> => {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			timer.unref?.();
+			try {
+				const res = await fetch(`${baseUrl}/chat/completions`, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						authorization: `Bearer ${apiKey}`,
+						"HTTP-Referer": process.env.NEXT_PUBLIC_APP_URL ?? "https://opencontext.ai",
+						"X-Title": "opencontext AI",
+					},
+					body: JSON.stringify({
+						model,
+						messages: [{ role: "user", content: prompt }],
+						temperature: 0,
+					}),
+					signal: controller.signal,
+				});
+				if (!res.ok) throw new Error(`reasoning LLM ${res.status}: ${await res.text()}`);
+				const body = (await res.json()) as {
+					choices?: Array<{ message?: { content?: string } }>;
+				};
+				const text = body.choices?.[0]?.message?.content?.trim();
+				if (!text) throw new Error("reasoning LLM response missing choices[0].message.content");
+				return text;
+			} finally {
+				clearTimeout(timer);
+			}
+		};
+
+		const queryRewriter = createUserVoiceRewriter({ complete });
+		const iterativePlanner = createIterativeRecallPlanner({ complete });
+
+		if (!unified.reasoning) unified.reasoning = {};
+		unified.reasoning.queryRewriter = queryRewriter;
+		unified.reasoning.iterativePlanner = iterativePlanner;
+		log(`reasoning wired (model=${model}, baseUrl=${baseUrl})`);
+	}
+
 	return unified;
 }
 
@@ -340,5 +435,24 @@ Cross-source search (wires unified.searchKnowledge / searchInsights / searchRawM
   --knowledge-backend <name>      chroma | none
                                   (env: KNOWLEDGE_BACKEND, default: none)
   --knowledge-collection <name>   Chroma collection (default: opencontext_knowledge)
-  Note: the chroma backends dynamically import @melandlabs/ai-rag.`);
+  Note: the chroma backends dynamically import @melandlabs/ai-rag.
+
+Reasoning (wires unified.reasoning.{queryRewriter, iterativePlanner}):
+  --reasoning                     Enable the LLM reasoning layer so /v1/search and
+                                  memory.search can honor reasoningStrategy:
+                                    "rewrite"    — first-person memory-check rephrase
+                                    "iterative"  — planner that searches, notes evidence,
+                                                   searches again
+                                  (env: REASONING=1, default: off)
+  --no-reasoning                  Explicitly disable even if REASONING=1 is set.
+  --reasoning-base-url <url>      OpenAI-compatible base URL for the reasoning LLM.
+                                  (env: OPENCONTEXT_LLM_BASE_URL, default: https://openrouter.ai/api/v1)
+  --reasoning-model <name>        Reasoning LLM model identifier.
+                                  (env: OPENCONTEXT_LLM_MODEL, default: openai/gpt-4o-mini)
+  --reasoning-timeout-ms <int>    Per-request timeout (default: 30000).
+
+  Required env when --reasoning is set:
+    OPENCONTEXT_LLM_API_KEY        Bearer token (no default)
+    OPENCONTEXT_LLM_BASE_URL       (optional) overrides --reasoning-base-url
+    OPENCONTEXT_LLM_MODEL          (optional) overrides --reasoning-model`);
 }


### PR DESCRIPTION
## Summary

- Adds a `--reasoning` flag (plus `--no-reasoning`, `--reasoning-base-url`, `--reasoning-model`, `--reasoning-timeout-ms`) to both `opencontext-memory-http` and `opencontext-memory-mcp` so the existing LLM reasoning layer (query-rewriter + iterative planner) is reachable from the CLI bins without writing a wrapper script. Reads `OPENCONTEXT_LLM_API_KEY` / `OPENCONTEXT_LLM_BASE_URL` / `OPENCONTEXT_LLM_MODEL` from the environment, so the `.env` the `@melandlabs/opencontext` facade already documents works as-is. No new SDK dep — the bin uses a raw OpenAI-compatible chat completions `fetch` against the supplied base URL, matching the pattern `cli-shared.ts` already uses for openrouter embeddings.
- Plumbs `reasoningStrategy` through both transports: `POST /v1/search` body and `memory.search` MCP tool schema now accept `"none" | "rewrite" | "iterative"` and forward it to `SearchInput.reasoningStrategy`. Before this change, the field was silently dropped by the HTTP handler and was missing from the MCP tool schema entirely — both surfaces accepted the SDK shape but discarded it on the wire.
- Reasoning stays **off by default**. If `OPENCONTEXT_LLM_API_KEY` is missing when `--reasoning` is set, the bin refuses to start with a clear remediation message rather than starting in a degraded state.

## Why

The reasoning providers (`createUserVoiceRewriter`, `createIterativeRecallPlanner`) were already in the SDK and exercised by the `examples/src/tutorials/10-reasoning-memory-example.ts` companion, but they were never reachable through the CLI daemons. Hosts that only consume `memory-store` (e.g. sidecar deployments of `@melandlabs/memory-store@1.1.6`) had no way to enable them without writing a Node wrapper. This closes that gap with one flag.

## How to use

```bash
# HTTP daemon
opencontext-memory-http \
  --reasoning \
  --embedding-provider local \
  --memory-backend sqlite-vec

# MCP daemon
opencontext-memory-mcp \
  --reasoning \
  --embedding-provider local \
  --memory-backend sqlite-vec
```

Then `POST /v1/search` / `memory.search` honors a `reasoningStrategy` body field. The response carries a `reasoning` block `{ strategy, iterations, evidenceCount, degraded }` so callers can observe what ran.

## Verification

End-to-end smoke against the DeepSeek model in `.env`:
- `iterative`: `result.reasoning.strategy === "iterative"`, `iterations > 0` (got 4), no `*_not_configured` warnings
- `rewrite`: `result.reasoning.strategy === "rewrite"`, no warnings
- baseline (no `reasoningStrategy`): no `reasoning.*` warnings, falls through cleanly

MCP path also confirmed — bin boots, wires `unified.reasoning.{queryRewriter, iterativePlanner}`, and `listening on stdio`.

## Docs

- `packages/memory-store/README.md` — Capabilities table, CLI bin section, Configuration matrix (`unified.reasoning.{queryRewriter, iterativePlanner, complete, defaultStrategy}`), Recipes 9 (HTTP) and 10 (MCP) extended with `--reasoning` examples.
- `docs/tutorials/03-advanced-usage.md` — new subsection "Exposing Reasoning Over HTTP and MCP" between the existing "Server-wide Default" and "Date-Range Filtering" sections, with the per-flag/env reference table.
- `packages/memory-store/CHANGELOG.md` — new `Unreleased` section with the four `Patch Changes` entries (cli-shared wiring, http.ts body plumbing, mcp.ts schema plumbing, cli-{http,mcp}.ts help updates).

## Out of scope

- Vitest coverage — there's no existing unit test for `cli-shared.ts`; adding stubbed-LLM coverage is a sensible follow-up but wasn't part of this change.
- Docs index / `packages/opencontext/README.md` updates — happy to add a follow-up if reviewers want the cross-package discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)