### PR TITLE
Fix/benchmark runnable baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,63 @@ jobs:
       - run: python -m py_compile benchmark/aml-local/serve.py benchmark/aml-local/test_contract.py
       - run: python benchmark/aml-local/test_contract.py
 
+  benchmark-smoke:
+    # Offline-only coverage for the supported benchmark entrypoints. This job
+    # must not receive provider credentials, contact paid models, or download
+    # full benchmark datasets.
+    name: Benchmark smoke (offline)
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_AUTH_TOKEN: ""
+      OPENROUTER_API_KEY: ""
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pnpm install --frozen-lockfile
+      - name: Typecheck benchmark CLIs
+        run: |
+          pnpm --filter @melandlabs/benchmark-locomo typecheck
+          pnpm --filter @melandlabs/benchmark-longmemeval typecheck
+          pnpm --filter @melandlabs/benchmark-beam typecheck
+      - name: Lint benchmark CLIs
+        run: |
+          pnpm exec biome lint benchmark/run-support.ts
+          pnpm --filter @melandlabs/benchmark-locomo lint
+          pnpm --filter @melandlabs/benchmark-longmemeval lint
+          pnpm --filter @melandlabs/benchmark-beam lint
+      - name: Check CLI help without preflight
+        run: |
+          pnpm --filter @melandlabs/benchmark-locomo benchmark -- --help
+          pnpm --filter @melandlabs/benchmark-longmemeval benchmark -- --help
+          pnpm --filter @melandlabs/benchmark-beam benchmark -- --help
+          python benchmark/beam/dataset/convert.py --help
+          python benchmark/aml-local/retrieve.py --help
+      - name: Run checkpoint, preflight, mapping, and AML fixture tests
+        run: |
+          pnpm --filter @melandlabs/benchmark-locomo test
+          pnpm --filter @melandlabs/benchmark-longmemeval test
+          (cd benchmark/beam/dataset && python -m unittest test_convert.py)
+          (cd benchmark/aml-local && python -m unittest test_retrieve.py)
+      - name: Convert bundled BEAM sample without Hugging Face dependencies
+        run: python benchmark/beam/dataset/convert.py --scale sample --out-dir "$RUNNER_TEMP/beam-sample"
+      - name: Confirm smoke tests did not change the checkout
+        run: |
+          if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+            git status --short --untracked-files=all
+            exit 1
+          fi
+
   lint:
     name: Lint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -193,8 +193,7 @@ benchmark/beam/dataset/beam_10m.json
 benchmark/scriptmem/dataset/raw/
 benchmark/scriptmem/dataset/scripts/
 
-# AML local experiment harness (local-only probes/builders, not for upstream)
-benchmark/aml-local/retrieve.py
+# AML local experiment helpers (local-only probes/builders, not for upstream)
 benchmark/aml-local/_probe_openrouter.py
 benchmark/aml-local/_lme_sample100_ids.txt
 benchmark/aml-local/build_union.py

--- a/benchmark/aml-local/README.md
+++ b/benchmark/aml-local/README.md
@@ -12,6 +12,15 @@ dataset -> retrieve.py -> OpenContext (POST /v1/raw-messages ingest, per-sample 
         -> judged.jsonl + aggregate score
 ```
 
+This is the **AML-compatible local evaluation** path. It uses public/local
+datasets with the vendored AML answer and scoring pipelines, so it is distinct
+from both:
+
+- the repository's internal TypeScript evaluations under `benchmark/locomo`,
+  `benchmark/longmemeval`, and `benchmark/beam`; and
+- the hosted AML leaderboard evaluation, which uses the platform's controlled
+  datasets and orchestration through the Add/Search adapter described below.
+
 ## Prerequisites
 
 - The OpenContext daemon is running (`curl http://127.0.0.1:7421/health`):
@@ -54,6 +63,12 @@ Common flags: `-Limit N` (number of samples; for personamem = number of personas
 already-ingested memories, re-retrieve only), `-Dataset beam_1m.json` (switch BEAM
 dataset), `-Mode mcq|generative` (personamem only, default mcq).
 
+Before retrieval, ingest, or model calls, the runner checks the dataset and
+sample filter, daemon, `OPENROUTER_API_KEY`, AML Python interpreter and `httpx`,
+pipeline files, output path, and arguments. All detected failures are reported
+together without printing secret values. `python retrieve.py --help` does not run
+preflight.
+
 PersonaMem-v2 reads `benchmark/personamem-v2/dataset/benchmark.csv` plus the
 per-persona 32k chat histories — fetch them with
 `python benchmark/personamem-v2/dataset/download.py --max-personas 5`. Each
@@ -72,7 +87,10 @@ The evaluate step scores all 457 gold questions; unanswered ones count as wrong,
 so use `-MaxQuestions` only for smoke tests and compare on full runs.
 
 Artifacts land in `outputs/<bench>/`: `input.jsonl` (retrieval results),
-`answers.jsonl` (generated answers), `judged.jsonl` (scoring details).
+`answers.jsonl` (generated answers), `judged.jsonl` (scoring details), and
+`run-manifest.json` (Git commit, dataset identity, models, retrieval settings,
+parameters, and wall-clock time). The vendored AML pipelines do not expose
+provider token usage, so the manifest records those fields as `null`.
 
 ## Local smoke baselines (2026-08-18, daemon: sqlite-vec + local embeddings)
 

--- a/benchmark/aml-local/fixtures/retrieve/clbench.jsonl
+++ b/benchmark/aml-local/fixtures/retrieve/clbench.jsonl
@@ -1,0 +1,1 @@
+{"metadata":{"task_id":"clbench-fixture-1"},"messages":[{"role":"user","content":"I use a standing desk."},{"role":"assistant","content":"Understood."},{"role":"user","content":"What kind of desk do I use?"}],"rubrics":[{"rubric_id":"r1","rubric_content":"Mentions a standing desk."}]}

--- a/benchmark/aml-local/fixtures/retrieve/locomo.json
+++ b/benchmark/aml-local/fixtures/retrieve/locomo.json
@@ -1,0 +1,19 @@
+[
+	{
+		"sample_id": "locomo-fixture-1",
+		"conversation": {
+			"session_1": [
+				{ "speaker": "Caroline", "text": "My favorite color is green." },
+				{ "speaker": "Melanie", "text": "I will remember that." }
+			],
+			"session_1_date_time": "2024-01-02T09:00:00Z"
+		},
+		"qa": [
+			{
+				"question": "What is Caroline's favorite color?",
+				"answer": "Green",
+				"category": 1
+			}
+		]
+	}
+]

--- a/benchmark/aml-local/fixtures/retrieve/longmemeval.json
+++ b/benchmark/aml-local/fixtures/retrieve/longmemeval.json
@@ -1,0 +1,16 @@
+[
+	{
+		"question_id": "lme-fixture-1",
+		"question": "Where does the user live?",
+		"question_type": "single-session-user",
+		"answer": "Berlin",
+		"haystack_session_ids": ["session-1"],
+		"haystack_dates": ["2024-05-01T10:00:00Z"],
+		"haystack_sessions": [
+			[
+				{ "role": "user", "content": "I moved to Berlin." },
+				{ "role": "assistant", "content": "I hope the move went well." }
+			]
+		]
+	}
+]

--- a/benchmark/aml-local/fixtures/retrieve/personamem/benchmark.csv
+++ b/benchmark/aml-local/fixtures/retrieve/personamem/benchmark.csv
@@ -1,0 +1,2 @@
+persona_id,chat_history_32k_link,user_query,correct_answer,incorrect_answers,preference
+persona-1,history.json,"{'role': 'user', 'content': 'Which pet would suit me?'}",A cat,"['A dog', 'A bird']",Prefers cats

--- a/benchmark/aml-local/fixtures/retrieve/personamem/history.json
+++ b/benchmark/aml-local/fixtures/retrieve/personamem/history.json
@@ -1,0 +1,6 @@
+{
+	"chat_history": [
+		{ "role": "user", "content": "Cats are my favorite pets." },
+		{ "role": "assistant", "content": "I will keep that preference in mind." }
+	]
+}

--- a/benchmark/aml-local/fixtures/retrieve/scriptmem/angry.json
+++ b/benchmark/aml-local/fixtures/retrieve/scriptmem/angry.json
@@ -1,0 +1,11 @@
+[
+	{
+		"sample_id": "fixture-1",
+		"conversation": {
+			"speakers": ["Juror 1", "Juror 2"],
+			"session_1": [{ "speaker": "Juror 1", "text": "The vote is not unanimous." }],
+			"session_1_date_time": "1957-01-01T00:00:00Z"
+		},
+		"qa": [{ "question": "Was the vote unanimous?", "qa_type": "single", "answer": "B" }]
+	}
+]

--- a/benchmark/aml-local/fixtures/retrieve/scriptmem/enemy.json
+++ b/benchmark/aml-local/fixtures/retrieve/scriptmem/enemy.json
@@ -1,0 +1,11 @@
+[
+	{
+		"sample_id": "fixture-1",
+		"conversation": {
+			"speakers": ["Thomas", "Peter"],
+			"session_1": [{ "speaker": "Thomas", "text": "The baths are contaminated." }],
+			"session_1_date_time": "1882-01-01T00:00:00Z"
+		},
+		"qa": [{ "question": "What is wrong with the baths?", "qa_type": "single", "answer": "A" }]
+	}
+]

--- a/benchmark/aml-local/fixtures/retrieve/scriptmem/friends.json
+++ b/benchmark/aml-local/fixtures/retrieve/scriptmem/friends.json
@@ -1,0 +1,11 @@
+[
+	{
+		"sample_id": "fixture-1",
+		"conversation": {
+			"speakers": ["Rachel", "Monica"],
+			"session_1": [{ "speaker": "Rachel", "text": "I left the wedding." }],
+			"session_1_date_time": "1994-09-22T00:00:00Z"
+		},
+		"qa": [{ "question": "What did Rachel leave?", "qa_type": "single", "answer": "C" }]
+	}
+]

--- a/benchmark/aml-local/fixtures/retrieve/scriptmem/man_earth.json
+++ b/benchmark/aml-local/fixtures/retrieve/scriptmem/man_earth.json
@@ -1,0 +1,11 @@
+[
+	{
+		"sample_id": "fixture-1",
+		"conversation": {
+			"speakers": ["John", "Dan"],
+			"session_1": [{ "speaker": "John", "text": "I am moving away." }],
+			"session_1_date_time": "2007-01-01T00:00:00Z"
+		},
+		"qa": [{ "question": "What is John planning to do?", "qa_type": "single", "answer": "D" }]
+	}
+]

--- a/benchmark/aml-local/retrieve.py
+++ b/benchmark/aml-local/retrieve.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import os
 import re
+import sys
 import time
 import urllib.request
 from datetime import datetime, timezone
@@ -111,6 +112,81 @@ def selected_ids(raw: str | None) -> set[str] | None:
         return None
     values = {part.strip() for part in raw.split(",") if part.strip()}
     return values or None
+
+
+def dataset_sample_ids(benchmark: str, dataset: Path) -> set[str]:
+    """Read only the identifiers needed to validate a requested sample filter."""
+    if benchmark == "scriptmem":
+        identifiers: set[str] = set()
+        for filename in SCRIPTMEM_FILES:
+            path = dataset / filename
+            for index, entry in enumerate(read_json(path)):
+                identifiers.add(str(entry.get("sample_id") or f"{path.stem}-{index}"))
+        return identifiers
+    if benchmark == "personamem":
+        with dataset.open(newline="", encoding="utf-8") as handle:
+            return {str(row["persona_id"]) for row in csv.DictReader(handle)}
+    if benchmark == "clbench":
+        rows = read_jsonl(dataset) if dataset.suffix == ".jsonl" else read_json(dataset)
+        return {
+            str((row.get("metadata") or {}).get("task_id") or f"cl_{index}")
+            for index, row in enumerate(rows)
+        }
+
+    payload = read_json(dataset)
+    if benchmark == "beam":
+        rows = payload.get("conversations", []) if isinstance(payload, dict) else payload
+        return {str(row.get("entry_id")) for row in rows}
+    key = "question_id" if benchmark == "longmemeval" else "sample_id"
+    return {str(row.get(key)) for row in payload}
+
+
+def check_writable_directory(path: Path) -> bool:
+    candidate = path.resolve()
+    while not candidate.exists() and candidate.parent != candidate:
+        candidate = candidate.parent
+    return candidate.is_dir() and os.access(candidate, os.W_OK)
+
+
+def collect_preflight_errors(
+    benchmark: str,
+    dataset: Path,
+    out_dir: Path,
+    client: "OpenContextClient",
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+) -> list[str]:
+    """Aggregate local retrieval failures before ingest or search side effects."""
+    errors: list[str] = []
+    if limit is not None and limit < 1:
+        errors.append("--limit must be a positive integer")
+    if max_questions is not None and max_questions < 1:
+        errors.append("--max-questions must be a positive integer")
+
+    dataset_readable = dataset.exists() and os.access(dataset, os.R_OK)
+    if not dataset_readable:
+        errors.append(f"dataset is missing or unreadable: {dataset.resolve()}")
+    else:
+        try:
+            available = dataset_sample_ids(benchmark, dataset)
+            if not available:
+                errors.append(f"dataset contains no benchmark samples: {dataset.resolve()}")
+            elif samples:
+                missing = sorted(samples - available)
+                if missing:
+                    errors.append(f"unknown --samples value(s): {', '.join(missing)}")
+        except Exception as error:  # noqa: BLE001 - malformed datasets must join the aggregate report
+            errors.append(f"dataset validation failed: {error}")
+
+    if not check_writable_directory(out_dir):
+        errors.append(f"output path is not writable: {out_dir.resolve()}")
+    try:
+        client.health()
+    except Exception as error:  # noqa: BLE001 - preflight must aggregate connection failures
+        errors.append(f"OpenContext daemon is unavailable at {client.base_url}: {error}")
+    return errors
 
 
 class OpenContextClient:
@@ -644,20 +720,29 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--skip-ingest", action="store_true", help="reuse an already-ingested sample scope")
     parser.add_argument("--max-questions", type=int, help="cap questions per selected sample")
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="validate local requirements without ingesting, searching, or writing output",
+    )
     return parser
 
 
 def main() -> int:
     args = build_parser().parse_args()
+    parameter_errors: list[str] = []
     reasoning = os.environ.get("AML_REASONING_STRATEGY", "none").strip().lower()
     if reasoning not in {"none", "rewrite", "iterative"}:
-        raise SystemExit("AML_REASONING_STRATEGY must be none, rewrite, or iterative")
+        parameter_errors.append("AML_REASONING_STRATEGY must be none, rewrite, or iterative")
+        reasoning = "none"
     try:
         top_k = int(os.environ.get("AML_TOP_K", "10"))
-    except ValueError as error:
-        raise SystemExit("AML_TOP_K must be an integer") from error
+    except ValueError:
+        parameter_errors.append("AML_TOP_K must be an integer")
+        top_k = 10
     if top_k < 1:
-        raise SystemExit("AML_TOP_K must be at least 1")
+        parameter_errors.append("AML_TOP_K must be at least 1")
+        top_k = 10
 
     dataset = default_dataset(args.benchmark, args.dataset)
     out_dir = Path(os.environ.get("AML_OUT_DIR", DEFAULT_OUT_DIR)).resolve()
@@ -666,18 +751,35 @@ def main() -> int:
         top_k,
         reasoning,
     )
-    client.health()
+    samples = selected_ids(args.samples)
+    errors = parameter_errors + collect_preflight_errors(
+        args.benchmark,
+        dataset,
+        out_dir,
+        client,
+        limit=args.limit,
+        samples=samples,
+        max_questions=args.max_questions,
+    )
+    if errors:
+        print("AML retrieval preflight failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
     print(
         f"[aml-local] daemon={client.base_url} top_k={top_k} "
         f"reasoning={reasoning} benchmark={args.benchmark}"
     )
+    if args.preflight_only:
+        print("[aml-local] preflight passed")
+        return 0
     run_benchmark(
         args.benchmark,
         dataset,
         client,
         out_dir,
         limit=args.limit,
-        samples=selected_ids(args.samples),
+        samples=samples,
         max_questions=args.max_questions,
         skip_ingest=args.skip_ingest,
     )

--- a/benchmark/aml-local/retrieve.py
+++ b/benchmark/aml-local/retrieve.py
@@ -1,0 +1,688 @@
+"""Retrieve OpenContext memories and emit AML-compatible benchmark JSONL.
+
+This is the local retrieval stage used by ``run_aml_local.ps1``. It reads one
+of the six existing benchmark formats, writes each sample to an isolated
+OpenContext ``userId``, searches that same scope, and emits the input expected
+by the vendored AML answer/evaluation pipelines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT_DIR = Path(__file__).resolve().parent / "outputs"
+BATCH_SIZE = 25
+BENCHMARKS = ("longmemeval", "locomo", "clbench", "beam", "personamem", "scriptmem")
+OUTPUT_NAMES = {
+    "longmemeval": "longmemeval-s",
+    "locomo": "locomo-refined",
+    "clbench": "clbench",
+    "beam": "beam",
+    "personamem": "personamem",
+    "scriptmem": "scriptmem",
+}
+SCRIPTMEM_FILES = ("angry.json", "enemy.json", "friends.json", "man_earth.json")
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    print(f"[aml-local] wrote {len(records)} records -> {path}")
+
+
+def parse_timestamp(value: Any, fallback: int) -> int:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if value:
+        try:
+            return int(datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp() * 1000)
+        except ValueError:
+            pass
+    return fallback
+
+
+def iso_from_ms(value: Any) -> str | None:
+    try:
+        return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def scope_id(benchmark: str, dataset: Path, sample_id: str) -> str:
+    dataset_name = dataset.name or dataset.parent.name
+    digest = hashlib.sha256(
+        f"{benchmark}\0{dataset_name}\0{sample_id}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"aml_{benchmark}_{digest}"
+
+
+def message_id(user_id: str, unit_id: str) -> str:
+    digest = hashlib.sha256(f"{user_id}\0{unit_id}".encode("utf-8")).hexdigest()[:16]
+    return f"{user_id}:{digest}"
+
+
+def raw_message(
+    benchmark: str,
+    user_id: str,
+    unit_id: str,
+    content: str,
+    timestamp: int,
+) -> dict[str, Any]:
+    return {
+        "messageId": message_id(user_id, unit_id),
+        "userId": user_id,
+        "platform": "benchmark",
+        "botId": f"aml-{benchmark}",
+        "timestamp": timestamp,
+        "createdAt": timestamp,
+        "content": content,
+    }
+
+
+def hit_texts(hits: list[dict[str, Any]]) -> list[str]:
+    return [str(hit.get("content", "")) for hit in hits]
+
+
+def selected_ids(raw: str | None) -> set[str] | None:
+    if not raw:
+        return None
+    values = {part.strip() for part in raw.split(",") if part.strip()}
+    return values or None
+
+
+class OpenContextClient:
+    def __init__(self, base_url: str, top_k: int, reasoning: str = "none") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.top_k = top_k
+        self.reasoning = reasoning
+
+    def _post(self, path: str, payload: dict[str, Any], timeout: int) -> dict[str, Any]:
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def health(self) -> None:
+        with urllib.request.urlopen(self.base_url + "/health", timeout=10) as response:
+            if response.status != 200:
+                raise RuntimeError(f"OpenContext daemon unhealthy: HTTP {response.status}")
+
+    def ingest(self, user_id: str, messages: list[dict[str, Any]]) -> int:
+        count = 0
+        for start in range(0, len(messages), BATCH_SIZE):
+            batch = messages[start : start + BATCH_SIZE]
+            result = self._post(
+                "/v1/raw-messages",
+                {"userId": user_id, "messages": batch, "embedOnInsert": True},
+                timeout=600,
+            )
+            count += int(result.get("count", len(batch)))
+        return count
+
+    def search(self, user_id: str, query: str) -> list[dict[str, Any]]:
+        payload: dict[str, Any] = {
+            "userId": user_id,
+            "query": query,
+            "limit": self.top_k,
+            "sources": ["memory"],
+        }
+        if self.reasoning != "none":
+            payload["reasoningStrategy"] = self.reasoning
+        result = self._post("/v1/search", payload, timeout=600 if self.reasoning != "none" else 120)
+        hits = result.get("results", [])
+        if not isinstance(hits, list):
+            raise TypeError("OpenContext /v1/search response must contain results[]")
+        return hits
+
+
+def run_longmemeval(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    del max_questions
+    entries = read_json(dataset)
+    if samples:
+        entries = [entry for entry in entries if str(entry.get("question_id")) in samples]
+    if limit:
+        entries = entries[:limit]
+
+    records: list[dict[str, Any]] = []
+    for entry in entries:
+        question_id = str(entry["question_id"])
+        user_id = scope_id("longmemeval", dataset, question_id)
+        messages: list[dict[str, Any]] = []
+        sessions = entry.get("haystack_sessions") or []
+        session_ids = entry.get("haystack_session_ids") or []
+        dates = entry.get("haystack_dates") or []
+        for index, turns in enumerate(sessions):
+            session_id = str(session_ids[index]) if index < len(session_ids) else f"session_{index}"
+            date = dates[index] if index < len(dates) else None
+            body = "\n".join(
+                f"{'User' if turn.get('role') == 'user' else 'Assistant'}: {turn.get('content', '')}"
+                for turn in turns
+            )
+            content = f"# Conversation Session {session_id}\n# Date: {date or ''}\n\n{body}"
+            messages.append(
+                raw_message(
+                    "longmemeval",
+                    user_id,
+                    session_id,
+                    content,
+                    parse_timestamp(date, index + 1),
+                )
+            )
+        if not skip_ingest and messages:
+            client.ingest(user_id, messages)
+        hits = client.search(user_id, str(entry["question"]))
+        records.append(
+            {
+                "id": question_id,
+                "question": entry["question"],
+                "question_type": entry.get("question_type"),
+                "retrieved_context": hit_texts(hits),
+                "gold_answer": entry.get("answer", ""),
+            }
+        )
+    return records
+
+
+def run_locomo(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    entries = read_json(dataset)
+    if samples:
+        entries = [entry for entry in entries if str(entry.get("sample_id")) in samples]
+    if limit:
+        entries = entries[:limit]
+
+    records: list[dict[str, Any]] = []
+    for entry in entries:
+        sample_id = str(entry["sample_id"])
+        user_id = scope_id("locomo", dataset, sample_id)
+        conversation = entry.get("conversation") or {}
+        messages: list[dict[str, Any]] = []
+        session_keys = sorted(
+            key
+            for key in conversation
+            if key.startswith("session_") and not key.endswith("_date_time")
+        )
+        for index, key in enumerate(session_keys):
+            turns = conversation.get(key) or []
+            if not isinstance(turns, list) or not turns:
+                continue
+            date = conversation.get(f"{key}_date_time")
+            body = "\n".join(f"{turn.get('speaker', '?')}: {turn.get('text', '')}" for turn in turns)
+            content = f"# Conversation {key}\n# Date: {date or ''}\n\n{body}"
+            messages.append(
+                raw_message("locomo", user_id, key, content, parse_timestamp(date, index + 1))
+            )
+        if not skip_ingest and messages:
+            client.ingest(user_id, messages)
+
+        questions = entry.get("qa") or entry.get("qa_pairs") or []
+        if max_questions:
+            questions = questions[:max_questions]
+        for index, question in enumerate(questions):
+            answer = question.get("answer")
+            if answer is None or (isinstance(answer, str) and not answer.strip()):
+                continue
+            hits = client.search(user_id, str(question["question"]))
+            records.append(
+                {
+                    "id": f"{sample_id}__q{index}",
+                    "question": question["question"],
+                    "category": question.get("category"),
+                    "retrieved_context": hit_texts(hits),
+                    "gold_answer": str(answer),
+                }
+            )
+    return records
+
+
+def run_clbench(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    del max_questions
+    rows = read_jsonl(dataset) if dataset.suffix == ".jsonl" else read_json(dataset)
+    if samples:
+        rows = [
+            row
+            for index, row in enumerate(rows)
+            if str((row.get("metadata") or {}).get("task_id") or f"cl_{index}") in samples
+        ]
+    if limit:
+        rows = rows[:limit]
+
+    records: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        metadata = row.get("metadata") or {}
+        task_id = str(metadata.get("task_id") or f"cl_{index}")
+        user_id = scope_id("clbench", dataset, task_id)
+        source_messages = row.get("messages") or []
+        context_messages = source_messages[:-1]
+        question = str(source_messages[-1].get("content", "")) if source_messages else ""
+        messages = [
+            raw_message(
+                "clbench",
+                user_id,
+                f"message_{message_index}",
+                f"{str(message.get('role', 'user')).capitalize()}: {message.get('content', '')}",
+                message_index + 1,
+            )
+            for message_index, message in enumerate(context_messages)
+        ]
+        if not skip_ingest and messages:
+            client.ingest(user_id, messages)
+        hits = client.search(user_id, question[:2000])
+        selected = []
+        for hit in hits:
+            item: dict[str, Any] = {"text": str(hit.get("content", ""))}
+            metadata_value = hit.get("metadata") or {}
+            created_at = iso_from_ms(metadata_value.get("timestamp") or metadata_value.get("createdAt"))
+            if created_at:
+                item["created_at"] = created_at
+            selected.append(item)
+        records.append(
+            {
+                "id": task_id,
+                "question": question,
+                "system_prompt": "",
+                "retrieval": {"selected": selected},
+                "rubrics": row.get("rubrics", []),
+                "metadata": metadata,
+            }
+        )
+    return records
+
+
+def run_beam(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    payload = read_json(dataset)
+    conversations = payload.get("conversations", []) if isinstance(payload, dict) else payload
+    if samples:
+        conversations = [entry for entry in conversations if str(entry.get("entry_id")) in samples]
+    if limit:
+        conversations = conversations[:limit]
+
+    records: list[dict[str, Any]] = []
+    for entry in conversations:
+        entry_id = str(entry["entry_id"])
+        user_id = scope_id("beam", dataset, entry_id)
+        chat = entry.get("chat") or []
+        messages: list[dict[str, Any]] = []
+        for chunk_index, start in enumerate(range(0, len(chat), 20)):
+            chunk = chat[start : start + 20]
+            body = "\n".join(
+                f"{turn.get('speaker', '?')}: {turn.get('text', '')}" for turn in chunk
+            )
+            timestamp = parse_timestamp(chunk[0].get("timestamp") if chunk else None, chunk_index + 1)
+            messages.append(raw_message("beam", user_id, f"chunk_{chunk_index}", body, timestamp))
+        if not skip_ingest and messages:
+            client.ingest(user_id, messages)
+
+        questions = entry.get("probing_questions") or []
+        if max_questions:
+            questions = questions[:max_questions]
+        for index, question in enumerate(questions):
+            question_id = str(question.get("question_id") or f"{entry_id}_q{index}")
+            hits = client.search(user_id, str(question.get("question", "")))
+            records.append(
+                {
+                    "id": question_id,
+                    "question": question.get("question", ""),
+                    "category": question.get("category"),
+                    "retrieved_context": hit_texts(hits),
+                    "rubric_nuggets": question.get("atoms") or question.get("rubrics") or [],
+                    "scale": entry.get("scale") or (payload.get("scale") if isinstance(payload, dict) else None),
+                }
+            )
+    return records
+
+
+def unwrap_user_query(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.startswith("{"):
+        try:
+            parsed = ast.literal_eval(text)
+            if isinstance(parsed, dict):
+                return str(parsed.get("content", parsed.get("text", text)))
+        except (SyntaxError, ValueError):
+            pass
+    return text
+
+
+def parse_incorrect_answers(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(text)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        except (json.JSONDecodeError, SyntaxError, ValueError):
+            pass
+    return []
+
+
+def run_personamem(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    with dataset.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    personas: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        persona_id = str(row["persona_id"])
+        persona = personas.setdefault(
+            persona_id,
+            {"history_link": row.get("chat_history_32k_link", ""), "questions": []},
+        )
+        persona["questions"].append(row)
+
+    persona_ids = [persona_id for persona_id in personas if not samples or persona_id in samples]
+    if limit:
+        persona_ids = persona_ids[:limit]
+
+    records: list[dict[str, Any]] = []
+    for persona_id in persona_ids:
+        persona = personas[persona_id]
+        user_id = scope_id("personamem", dataset, persona_id)
+        history_path = dataset.parent / str(persona["history_link"])
+        history_payload = read_json(history_path)
+        history = history_payload.get("chat_history", history_payload)
+        messages: list[dict[str, Any]] = []
+        for chunk_index, start in enumerate(range(0, len(history), 20)):
+            chunk = history[start : start + 20]
+            body = "\n".join(
+                f"{str(message.get('role', 'user')).capitalize()}: {message.get('content', '')}"
+                for message in chunk
+            )
+            messages.append(
+                raw_message("personamem", user_id, f"chunk_{chunk_index}", body, chunk_index + 1)
+            )
+        if not skip_ingest and messages:
+            client.ingest(user_id, messages)
+
+        questions = persona["questions"]
+        if max_questions:
+            questions = questions[:max_questions]
+        for index, question in enumerate(questions):
+            query = unwrap_user_query(question.get("user_query", ""))
+            hits = client.search(user_id, query)
+            memory = "\n\n".join(hit_texts(hits))
+            chat_history = []
+            if memory:
+                chat_history.append(
+                    {
+                        "role": "system",
+                        "content": "Relevant memories from earlier conversation:\n\n" + memory,
+                    }
+                )
+            records.append(
+                {
+                    "id": f"persona{persona_id}_q{index}",
+                    "persona_id": persona_id,
+                    "chat_history": chat_history,
+                    "user_query": query,
+                    "correct_answer": question.get("correct_answer", ""),
+                    "incorrect_answers": parse_incorrect_answers(question.get("incorrect_answers", "")),
+                    "preference": question.get("preference", ""),
+                }
+            )
+    return records
+
+
+def session_sort_key(key: str) -> tuple[int, str]:
+    match = re.search(r"(\d+)", key)
+    return (int(match.group(1)) if match else 0, key)
+
+
+def run_scriptmem(
+    dataset: Path,
+    client: OpenContextClient,
+    *,
+    limit: int | None,
+    samples: set[str] | None,
+    max_questions: int | None,
+    skip_ingest: bool,
+) -> list[dict[str, Any]]:
+    paths = [dataset / filename for filename in SCRIPTMEM_FILES]
+    missing = [path.name for path in paths if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"ScriptMem dataset is missing: {', '.join(missing)}")
+
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        source = path.stem
+        entries = read_json(path)
+        if samples:
+            entries = [entry for entry in entries if str(entry.get("sample_id")) in samples]
+        if limit:
+            entries = entries[:limit]
+        for sample_index, entry in enumerate(entries):
+            sample_id = str(entry.get("sample_id") or f"{source}-{sample_index}")
+            user_id = scope_id("scriptmem", dataset, f"{source}:{sample_id}")
+            conversation = entry.get("conversation") or {}
+            if not any(key.startswith("session_") for key in conversation):
+                candidate = conversation.get("format_example")
+                if isinstance(candidate, dict):
+                    conversation = candidate
+            speakers = conversation.get("speakers") or []
+            session_keys = sorted(
+                (
+                    key
+                    for key in conversation
+                    if key.startswith("session_") and not key.endswith("_date_time")
+                ),
+                key=session_sort_key,
+            )
+            messages: list[dict[str, Any]] = []
+            for session_index, key in enumerate(session_keys):
+                turns = conversation.get(key) or []
+                if not isinstance(turns, list) or not turns:
+                    continue
+                date = conversation.get(f"{key}_date_time")
+                body = "\n".join(
+                    f"{turn.get('speaker') or 'Narration'}: {turn.get('text', '')}" for turn in turns
+                )
+                messages.append(
+                    raw_message(
+                        "scriptmem",
+                        user_id,
+                        key,
+                        body,
+                        parse_timestamp(date, session_index + 1),
+                    )
+                )
+            if not skip_ingest and messages:
+                client.ingest(user_id, messages)
+
+            questions = entry.get("qa") or []
+            if max_questions:
+                questions = questions[:max_questions]
+            for question_index, question in enumerate(questions):
+                question_id = f"{source}:{sample_id}#q{question_index:04d}"
+                hits = client.search(user_id, str(question["question"]))
+                records.append(
+                    {
+                        "id": question_id,
+                        "qa_id": question_id,
+                        "dataset": source,
+                        "question": question["question"],
+                        "qa_type": question.get("qa_type"),
+                        "speaker_1_name": speakers[0] if len(speakers) > 0 else "speaker 1",
+                        "speaker_1_memories": "\n\n".join(hit_texts(hits)),
+                        "speaker_2_name": speakers[1] if len(speakers) > 1 else "speaker 2",
+                        "speaker_2_memories": "",
+                    }
+                )
+    return records
+
+
+RUNNERS: dict[str, Callable[..., list[dict[str, Any]]]] = {
+    "longmemeval": run_longmemeval,
+    "locomo": run_locomo,
+    "clbench": run_clbench,
+    "beam": run_beam,
+    "personamem": run_personamem,
+    "scriptmem": run_scriptmem,
+}
+
+
+def default_dataset(benchmark: str, dataset_arg: str | None) -> Path:
+    if dataset_arg:
+        candidate = Path(dataset_arg)
+        if candidate.is_absolute():
+            return candidate
+        if benchmark == "beam":
+            return BENCH_ROOT / "beam" / "dataset" / candidate
+        return candidate.resolve()
+    defaults = {
+        "longmemeval": BENCH_ROOT / "longmemeval" / "dataset" / "longmemeval_s_cleaned.json",
+        "locomo": BENCH_ROOT / "locomo" / "dataset" / "locomo_v2.json",
+        "clbench": BENCH_ROOT / "clbench-official" / "CL-bench-Life.jsonl",
+        "beam": BENCH_ROOT / "beam" / "dataset" / "sample_conversation.json",
+        "personamem": BENCH_ROOT / "personamem-v2" / "dataset" / "benchmark.csv",
+        "scriptmem": BENCH_ROOT / "scriptmem" / "dataset" / "raw",
+    }
+    return defaults[benchmark]
+
+
+def run_benchmark(
+    benchmark: str,
+    dataset: Path,
+    client: OpenContextClient,
+    out_dir: Path,
+    *,
+    limit: int | None = None,
+    samples: set[str] | None = None,
+    max_questions: int | None = None,
+    skip_ingest: bool = False,
+) -> Path:
+    records = RUNNERS[benchmark](
+        dataset,
+        client,
+        limit=limit,
+        samples=samples,
+        max_questions=max_questions,
+        skip_ingest=skip_ingest,
+    )
+    output = out_dir / OUTPUT_NAMES[benchmark] / "input.jsonl"
+    write_jsonl(output, records)
+    return output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Ingest a local benchmark into OpenContext and emit AML-compatible input JSONL"
+    )
+    parser.add_argument("benchmark", choices=BENCHMARKS)
+    parser.add_argument("--limit", type=int, help="limit benchmark samples/conversations")
+    parser.add_argument("--samples", help="comma-separated sample IDs")
+    parser.add_argument(
+        "--dataset",
+        help="dataset override; BEAM relative paths resolve under benchmark/beam/dataset",
+    )
+    parser.add_argument("--skip-ingest", action="store_true", help="reuse an already-ingested sample scope")
+    parser.add_argument("--max-questions", type=int, help="cap questions per selected sample")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    reasoning = os.environ.get("AML_REASONING_STRATEGY", "none").strip().lower()
+    if reasoning not in {"none", "rewrite", "iterative"}:
+        raise SystemExit("AML_REASONING_STRATEGY must be none, rewrite, or iterative")
+    try:
+        top_k = int(os.environ.get("AML_TOP_K", "10"))
+    except ValueError as error:
+        raise SystemExit("AML_TOP_K must be an integer") from error
+    if top_k < 1:
+        raise SystemExit("AML_TOP_K must be at least 1")
+
+    dataset = default_dataset(args.benchmark, args.dataset)
+    out_dir = Path(os.environ.get("AML_OUT_DIR", DEFAULT_OUT_DIR)).resolve()
+    client = OpenContextClient(
+        os.environ.get("OPENCONTEXT_URL", "http://127.0.0.1:7421"),
+        top_k,
+        reasoning,
+    )
+    client.health()
+    print(
+        f"[aml-local] daemon={client.base_url} top_k={top_k} "
+        f"reasoning={reasoning} benchmark={args.benchmark}"
+    )
+    run_benchmark(
+        args.benchmark,
+        dataset,
+        client,
+        out_dir,
+        limit=args.limit,
+        samples=selected_ids(args.samples),
+        max_questions=args.max_questions,
+        skip_ingest=args.skip_ingest,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/aml-local/run_aml_local.ps1
+++ b/benchmark/aml-local/run_aml_local.ps1
@@ -33,11 +33,10 @@ param(
   [string]$Tag = ""
 )
 
-$ErrorActionPreference = "Stop"
+$startedAt = [DateTimeOffset]::UtcNow
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $amlRepo = Join-Path $here "..\AML-agent-memory-leaderboard"
 $python = Join-Path $amlRepo ".venv\Scripts\python.exe"
-if (-not (Test-Path $python)) { throw "AML venv missing: $python (run: uv venv .venv; uv pip install -r requirements.txt in the AML repo dir)" }
 
 # load .env (OPENROUTER_API_KEY etc.)
 $envFile = Join-Path $here ".env"
@@ -48,15 +47,6 @@ if (Test-Path $envFile) {
     [Environment]::SetEnvironmentVariable($k.Trim(), $v.Trim(), 'Process')
   }
 }
-if (-not $env:OPENROUTER_API_KEY) { throw "OPENROUTER_API_KEY missing — put it in $envFile" }
-
-# AML api_config.py env surface
-$env:ANSWER_API_BASE = "https://openrouter.ai/api/v1"
-$env:ANSWER_API_KEY  = $env:OPENROUTER_API_KEY
-$env:ANSWER_MODEL    = $AnswerModel
-$env:JUDGE_API_BASE  = "https://openrouter.ai/api/v1"
-$env:JUDGE_API_KEY   = $env:OPENROUTER_API_KEY
-$env:JUDGE_MODEL     = $JudgeModel
 
 $dataDir = @{ longmemeval = "longmemeval-s"; locomo = "locomo-refined"; clbench = "clbench"; beam = "beam"; personamem = "personamem"; scriptmem = "scriptmem" }[$Bench]
 $outRoot = if ($Tag) { "outputs-$Tag" } else { "outputs" }
@@ -70,14 +60,110 @@ $pipelineFile = if ($Bench -eq "personamem") { "pipeline_v2.py" } else { "pipeli
 $pipeline = Join-Path $amlRepo "data\$dataDir\$pipelineFile"
 # run pipelines through the runtime shim so the vendored AML repo stays unmodified
 $shim = Join-Path $here "run_pipeline.py"
+$retrieve = Join-Path $here "retrieve.py"
+$datasetPath = switch ($Bench) {
+  "longmemeval" { Join-Path $here "..\longmemeval\dataset\longmemeval_s_cleaned.json" }
+  "locomo" { Join-Path $here "..\locomo\dataset\locomo_v2.json" }
+  "clbench" { Join-Path $here "..\clbench-official\CL-bench-Life.jsonl" }
+  "beam" {
+    if ([IO.Path]::IsPathRooted($Dataset)) { $Dataset } else { Join-Path $here "..\beam\dataset\$Dataset" }
+  }
+  "personamem" { Join-Path $here "..\personamem-v2\dataset\benchmark.csv" }
+  "scriptmem" { Join-Path $here "..\scriptmem\dataset\raw" }
+}
 
-Write-Host "=== [1/3] retrieve ($Bench) ==="
-$retrieveArgs = @((Join-Path $here "retrieve.py"), $Bench)
+$retrieveArgs = @($retrieve, $Bench)
 if ($Limit -gt 0)   { $retrieveArgs += @("--limit", $Limit) }
 if ($Samples)       { $retrieveArgs += @("--samples", $Samples) }
 if ($Bench -eq "beam") { $retrieveArgs += @("--dataset", $Dataset) }
 if ($SkipIngest)    { $retrieveArgs += "--skip-ingest" }
 if ($MaxQuestions -gt 0) { $retrieveArgs += @("--max-questions", $MaxQuestions) }
+
+function Test-WritableTarget([string]$TargetPath) {
+  $candidate = [IO.Path]::GetFullPath($TargetPath)
+  while (-not (Test-Path -LiteralPath $candidate)) {
+    $parent = Split-Path -Parent $candidate
+    if (-not $parent -or $parent -eq $candidate) { return $false }
+    $candidate = $parent
+  }
+  if (-not (Test-Path -LiteralPath $candidate -PathType Container)) { return $false }
+  $probe = Join-Path $candidate (".opencontext-preflight-{0}.tmp" -f [Guid]::NewGuid())
+  try {
+    [IO.File]::WriteAllText($probe, "")
+    return $true
+  } catch {
+    return $false
+  } finally {
+    if (Test-Path -LiteralPath $probe) { Remove-Item -LiteralPath $probe -Force }
+  }
+}
+
+$preflightErrors = [Collections.Generic.List[string]]::new()
+if ($Limit -lt 0) { $preflightErrors.Add("-Limit must be zero or a positive integer") }
+if ($MaxQuestions -lt 0) { $preflightErrors.Add("-MaxQuestions must be zero or a positive integer") }
+if (-not $env:OPENROUTER_API_KEY) { $preflightErrors.Add("OPENROUTER_API_KEY is missing; set it in the process or $envFile") }
+foreach ($requiredFile in @($retrieve, $shim, $pipeline)) {
+  if (-not (Test-Path -LiteralPath $requiredFile -PathType Leaf)) {
+    $preflightErrors.Add("required AML file is missing: $requiredFile")
+  }
+}
+if (-not (Test-WritableTarget $env:AML_OUT_DIR)) {
+  $preflightErrors.Add("AML output path is not writable: $($env:AML_OUT_DIR)")
+}
+
+$topK = 10
+if ($env:AML_TOP_K) {
+  $parsedTopK = 0
+  if (-not [int]::TryParse($env:AML_TOP_K, [ref]$parsedTopK) -or $parsedTopK -lt 1) {
+    $preflightErrors.Add("AML_TOP_K must be an integer of at least 1")
+    $env:AML_TOP_K = "10"
+  } else {
+    $topK = $parsedTopK
+  }
+}
+
+if (-not (Test-Path -LiteralPath $python -PathType Leaf)) {
+  $preflightErrors.Add("AML Python interpreter is missing: $python")
+  if (-not (Test-Path -LiteralPath $datasetPath)) {
+    $preflightErrors.Add("benchmark dataset is missing: $datasetPath")
+  }
+  $daemonUrl = if ($env:OPENCONTEXT_URL) { $env:OPENCONTEXT_URL.TrimEnd("/") } else { "http://127.0.0.1:7421" }
+  try {
+    $null = Invoke-WebRequest "$daemonUrl/health" -TimeoutSec 5
+  } catch {
+    $preflightErrors.Add("OpenContext daemon is unavailable at $daemonUrl")
+  }
+} else {
+  $null = & $python -c "import httpx" 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $preflightErrors.Add("AML Python dependency is missing: httpx")
+  }
+  $retrievePreflight = @(& $python @retrieveArgs --preflight-only 2>&1)
+  if ($LASTEXITCODE -ne 0) {
+    foreach ($line in $retrievePreflight) {
+      $message = "$line".Trim()
+      if ($message -and $message -ne "AML retrieval preflight failed:") {
+        $preflightErrors.Add($message)
+      }
+    }
+  }
+}
+
+if ($preflightErrors.Count -gt 0) {
+  $uniqueErrors = $preflightErrors | Select-Object -Unique
+  throw "AML benchmark preflight failed:`n$($uniqueErrors | ForEach-Object { "- $_" } | Out-String)"
+}
+
+$ErrorActionPreference = "Stop"
+# AML api_config.py env surface; only set after every preflight check passed.
+$env:ANSWER_API_BASE = "https://openrouter.ai/api/v1"
+$env:ANSWER_API_KEY  = $env:OPENROUTER_API_KEY
+$env:ANSWER_MODEL    = $AnswerModel
+$env:JUDGE_API_BASE  = "https://openrouter.ai/api/v1"
+$env:JUDGE_API_KEY   = $env:OPENROUTER_API_KEY
+$env:JUDGE_MODEL     = $JudgeModel
+
+Write-Host "=== [1/3] retrieve ($Bench) ==="
 & $python @retrieveArgs
 if ($LASTEXITCODE -ne 0) { throw "retrieve failed" }
 
@@ -108,6 +194,62 @@ if ($Bench -eq "personamem") {
   & $python $shim $pipeline evaluate --input $input --answers $answers --output $judged
 }
 if ($LASTEXITCODE -ne 0) { throw "evaluate failed" }
+
+function Get-DatasetIdentity([string]$Path) {
+  $item = Get-Item -LiteralPath $Path
+  if ($item.PSIsContainer) {
+    $files = @(Get-ChildItem -LiteralPath $item.FullName -File -Recurse)
+    $size = ($files | Measure-Object -Property Length -Sum).Sum
+    if ($null -eq $size) { $size = 0 }
+    return [ordered]@{
+      path = $item.FullName
+      size_bytes = [long]$size
+      mtime_ms = ([DateTimeOffset]$item.LastWriteTimeUtc).ToUnixTimeMilliseconds()
+      sha256 = $null
+    }
+  }
+  $hash = if ($item.Length -le 268435456) { (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256).Hash.ToLowerInvariant() } else { $null }
+  return [ordered]@{
+    path = $item.FullName
+    size_bytes = [long]$item.Length
+    mtime_ms = ([DateTimeOffset]$item.LastWriteTimeUtc).ToUnixTimeMilliseconds()
+    sha256 = $hash
+  }
+}
+
+$finishedAt = [DateTimeOffset]::UtcNow
+$gitCommit = $null
+try {
+  $gitCommit = (& git -C (Join-Path $here "..\..") rev-parse HEAD 2>$null).Trim()
+  if (-not $gitCommit) { $gitCommit = $null }
+} catch {
+  $gitCommit = $null
+}
+$manifest = [ordered]@{
+  schema_version = 1
+  benchmark = "aml-local/$Bench"
+  git_commit = $gitCommit
+  dataset = Get-DatasetIdentity $datasetPath
+  answerer_model = $AnswerModel
+  judge_model = $JudgeModel
+  retrieval = [ordered]@{ strategy = $Reasoning; top_k = $topK }
+  resume = $false
+  started_at = $startedAt.ToString("o")
+  finished_at = $finishedAt.ToString("o")
+  wall_clock_ms = [long]($finishedAt - $startedAt).TotalMilliseconds
+  token_usage = [ordered]@{ prompt_tokens = $null; completion_tokens = $null; total_tokens = $null }
+  parameters = [ordered]@{
+    limit = if ($Limit -gt 0) { $Limit } else { $null }
+    samples = if ($Samples) { $Samples } else { $null }
+    max_questions = if ($MaxQuestions -gt 0) { $MaxQuestions } else { $null }
+    mode = if ($Bench -eq "personamem") { $Mode } else { $null }
+    skip_ingest = [bool]$SkipIngest
+  }
+}
+$manifestPath = Join-Path $outDir "run-manifest.json"
+New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+$manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+Write-Host "manifest: $manifestPath"
 
 # ---- summary ----
 if ($Bench -eq "scriptmem") {

--- a/benchmark/aml-local/test_retrieve.py
+++ b/benchmark/aml-local/test_retrieve.py
@@ -1,0 +1,198 @@
+"""Offline fixture and mock HTTP tests for the AML retrieval stage."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("aml_local_retrieve", HERE / "retrieve.py")
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load retrieve.py")
+retrieve = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = retrieve
+SPEC.loader.exec_module(retrieve)
+
+
+class MockDaemon(ThreadingHTTPServer):
+    requests: list[tuple[str, dict[str, Any]]]
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), MockHandler)
+        self.requests = []
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    server: MockDaemon
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        pass
+
+    def send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self.send_json(200, {"ok": True})
+            return
+        self.send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        self.server.requests.append((self.path, payload))
+        if self.path == "/v1/raw-messages":
+            self.send_json(200, {"ok": True, "count": len(payload["messages"])})
+            return
+        if self.path == "/v1/search":
+            self.send_json(
+                200,
+                {
+                    "results": [
+                        {
+                            "id": "memory-1",
+                            "content": f"retrieved: {payload['query']}",
+                            "similarity": 0.9,
+                            "metadata": {"timestamp": 1_700_000_000_000},
+                        }
+                    ]
+                },
+            )
+            return
+        self.send_json(404, {"error": "not found"})
+
+
+class RetrieveFixtureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = MockDaemon()
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        host, port = cls.server.server_address
+        cls.client = retrieve.OpenContextClient(f"http://{host}:{port}", top_k=3)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    def setUp(self) -> None:
+        self.server.requests.clear()
+
+    def fixture_cases(self) -> dict[str, tuple[Path, set[str]]]:
+        fixture_root = HERE / "fixtures" / "retrieve"
+        return {
+            "longmemeval": (
+                fixture_root / "longmemeval.json",
+                {"id", "question", "question_type", "retrieved_context", "gold_answer"},
+            ),
+            "locomo": (
+                fixture_root / "locomo.json",
+                {"id", "question", "category", "retrieved_context", "gold_answer"},
+            ),
+            "clbench": (
+                fixture_root / "clbench.jsonl",
+                {"id", "question", "retrieval", "rubrics", "metadata"},
+            ),
+            "beam": (
+                HERE.parent / "beam" / "dataset" / "sample_conversation.json",
+                {"id", "question", "category", "retrieved_context", "rubric_nuggets", "scale"},
+            ),
+            "personamem": (
+                fixture_root / "personamem" / "benchmark.csv",
+                {
+                    "id",
+                    "persona_id",
+                    "chat_history",
+                    "user_query",
+                    "correct_answer",
+                    "incorrect_answers",
+                    "preference",
+                },
+            ),
+            "scriptmem": (
+                fixture_root / "scriptmem",
+                {
+                    "id",
+                    "qa_id",
+                    "dataset",
+                    "question",
+                    "qa_type",
+                    "speaker_1_name",
+                    "speaker_1_memories",
+                    "speaker_2_name",
+                    "speaker_2_memories",
+                },
+            ),
+        }
+
+    def run_case(self, benchmark: str, dataset: Path, output_root: Path) -> tuple[list[dict], list[str]]:
+        self.server.requests.clear()
+        self.client.health()
+        output = retrieve.run_benchmark(
+            benchmark,
+            dataset,
+            self.client,
+            output_root,
+            max_questions=1,
+        )
+        rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+
+        add_requests = [payload for path, payload in self.server.requests if path == "/v1/raw-messages"]
+        search_requests = [payload for path, payload in self.server.requests if path == "/v1/search"]
+        self.assertTrue(add_requests, f"{benchmark} did not ingest fixture messages")
+        self.assertTrue(search_requests, f"{benchmark} did not search fixture questions")
+
+        added_user_ids = {payload["userId"] for payload in add_requests}
+        for payload in add_requests:
+            self.assertTrue(payload["embedOnInsert"])
+            for message in payload["messages"]:
+                self.assertEqual(payload["userId"], message["userId"])
+        for payload in search_requests:
+            self.assertIn(payload["userId"], added_user_ids)
+            self.assertEqual(payload["limit"], 3)
+            self.assertEqual(payload["sources"], ["memory"])
+
+        message_ids = [
+            message["messageId"]
+            for payload in add_requests
+            for message in payload["messages"]
+        ]
+        self.assertEqual(len(message_ids), len(set(message_ids)))
+        return rows, message_ids
+
+    def test_all_six_benchmarks_emit_pipeline_records_over_current_http_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_root = Path(temp_dir)
+            for benchmark, (dataset, required_keys) in self.fixture_cases().items():
+                with self.subTest(benchmark=benchmark):
+                    first_rows, first_ids = self.run_case(benchmark, dataset, output_root)
+                    second_rows, second_ids = self.run_case(benchmark, dataset, output_root)
+                    self.assertTrue(first_rows)
+                    self.assertTrue(required_keys.issubset(first_rows[0]))
+                    self.assertEqual(first_rows, second_rows)
+                    self.assertEqual(first_ids, second_ids)
+
+    def test_dataset_and_sample_scopes_are_distinct_and_repeatable(self) -> None:
+        first = retrieve.scope_id("beam", Path("beam_1m.json"), "sample-1")
+        self.assertEqual(first, retrieve.scope_id("beam", Path("beam_1m.json"), "sample-1"))
+        self.assertNotEqual(first, retrieve.scope_id("beam", Path("beam_10m.json"), "sample-1"))
+        self.assertNotEqual(first, retrieve.scope_id("beam", Path("beam_1m.json"), "sample-2"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/aml-local/test_retrieve.py
+++ b/benchmark/aml-local/test_retrieve.py
@@ -93,6 +93,45 @@ class RetrieveFixtureTests(unittest.TestCase):
     def setUp(self) -> None:
         self.server.requests.clear()
 
+    def test_preflight_aggregates_parameter_dataset_and_daemon_failures(self) -> None:
+        class FailingClient:
+            base_url = "http://127.0.0.1:1"
+
+            @staticmethod
+            def health() -> None:
+                raise OSError("connection refused")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            errors = retrieve.collect_preflight_errors(
+                "beam",
+                Path(temp_dir) / "missing.json",
+                Path(temp_dir) / "outputs",
+                FailingClient(),
+                limit=0,
+                samples={"missing-sample"},
+                max_questions=0,
+            )
+
+        self.assertIn("--limit must be a positive integer", errors)
+        self.assertIn("--max-questions must be a positive integer", errors)
+        self.assertTrue(any("dataset is missing or unreadable" in error for error in errors))
+        self.assertTrue(any("daemon is unavailable" in error for error in errors))
+
+    def test_preflight_rejects_unknown_sample_before_retrieval(self) -> None:
+        dataset = HERE.parent / "beam" / "dataset" / "sample_conversation.json"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            errors = retrieve.collect_preflight_errors(
+                "beam",
+                dataset,
+                Path(temp_dir),
+                self.client,
+                limit=1,
+                samples={"not-present"},
+                max_questions=1,
+            )
+
+        self.assertEqual(errors, ["unknown --samples value(s): not-present"])
+
     def fixture_cases(self) -> dict[str, tuple[Path, set[str]]]:
         fixture_root = HERE / "fixtures" / "retrieve"
         return {

--- a/benchmark/beam/README.md
+++ b/benchmark/beam/README.md
@@ -77,7 +77,7 @@ benchmark/beam/
 | Scoring            | binary CORRECT/WRONG                  | **nugget 0.0/0.5/1.0 per atom**                   |
 | Judge              | 1 binary prompt                       | **rubric + 1-shot** (`BEAM_NUGGET_JUDGE_PROMPT`)  |
 | Ingest             | 1 memory message per session          | **20 turns per memory message**                   |
-| Resume             | on error or wrong                     | on error only (judge re-runs)                     |
+| Resume             | Reuse all completed results; retry execution failures | Reuse completed judge results; retry errors |
 | Per-question score | `correct: bool`                       | `nugget_mean + nugget_pass (≥0.5)`                |
 
 ## CLI
@@ -86,8 +86,10 @@ benchmark/beam/
 # Show help
 pnpm --filter @melandlabs/benchmark-beam benchmark -- --help
 
-# Smoke test (uses bundled sample, no HF download)
+# Offline data-preparation smoke (no credentials or HF download)
 python dataset/convert.py --scale sample
+
+# Local evaluation smoke (requires daemon + provider credentials; incurs model calls)
 pnpm --filter @melandlabs/benchmark-beam benchmark -- \
   --dataset dataset/sample_conversation.json
 
@@ -117,6 +119,12 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
 | `-p, --port <n>`                 | OpenContext memory daemon port (default: 7421, env: `OPENCONTEXT_PORT` / `OPENCONTEXT_URL`) |
 | `-o, --output <path>`            | Write results JSON to this path                     |
 
+Before ingest or model calls, the CLI checks the dataset and filters, daemon,
+credentials, output/checkpoint paths, and arguments. It reports all detected
+failures together and never prints credential values. `--help` does not run
+these checks. `--resume` reuses completed judge results regardless of pass/fail;
+`--no-resume` ignores existing checkpoints.
+
 ## Output JSON shape
 
 ```jsonc
@@ -126,6 +134,8 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
   "conversations_run": 35,
   "questions_run": 700,
   "categories_filter": null,
+  "token_usage": { "prompt_tokens": 1000, "completion_tokens": 200, "total_tokens": 1200 },
+  "run_manifest": { "schema_version": 1, "git_commit": "...", "wall_clock_ms": 12345, … },
   "summary": {
     "count": 700,
     "nugget_mean": 0.62,
@@ -158,6 +168,11 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
 }
 ```
 
+Provider usage is recorded when returned; unavailable values are `null`, never a
+fabricated zero. With `--output results.json`, the same manifest is also written
+to `results.json.manifest.json`; without `--output`, it is written under
+`results/`.
+
 ## Smoke-test checklist
 
 ```bash
@@ -172,7 +187,7 @@ node packages/opencontext/dist/cli/opencontext.js http \
 # 3. Generate sample (offline, no HF download)
 python dataset/convert.py --scale sample
 
-# 4. Run smoke test
+# 4. Run the local evaluation smoke (this uses configured paid model providers)
 pnpm --filter @melandlabs/benchmark-beam benchmark -- \
   --dataset dataset/sample_conversation.json \
   --output results/sample_run.json
@@ -224,5 +239,6 @@ bounded at 3 attempts.
 
 - Paper: Tavakoli et al., "BEAM: Benchmarking EffecTive Agent Memory",
   ICLR 2026. arXiv:2510.27246.
-- Dataset: <https://huggingface.co/datasets/Mohammadta/BEAM>
+- Datasets: <https://huggingface.co/datasets/Mohammadta/BEAM> (`128k`, `500k`,
+  `1m`) and <https://huggingface.co/datasets/Mohammadta/BEAM-10M> (`10m`)
 - Leaderboard: see paper §6.

--- a/benchmark/beam/dataset/README.md
+++ b/benchmark/beam/dataset/README.md
@@ -13,18 +13,36 @@ TypeScript runner expects (one JSON file per scale).
 ## Quickstart
 
 ```bash
-# 1. Install Python deps (one-time)
+# Offline sample conversion: no Hugging Face dependency or network access
+python dataset/convert.py --scale sample
+
+# Non-sample conversion: install dependencies once
 pip install pyarrow datasets
 
-# 2. Convert a scale
+# Convert a published scale
+python dataset/convert.py --scale 128k   # writes dataset/beam_128k.json
+python dataset/convert.py --scale 500k   # writes dataset/beam_500k.json
 python dataset/convert.py --scale 1m     # writes dataset/beam_1m.json
 python dataset/convert.py --scale 10m    # writes dataset/beam_10m.json
-python dataset/convert.py --scale sample # writes sample_conversation.json (no HF download)
 
-# 3. Run the benchmark
+# Run the local TypeScript evaluation (requires daemon and model credentials)
 pnpm --filter @melandlabs/benchmark-beam benchmark -- \
   --dataset dataset/sample_conversation.json
 ```
+
+## Published source mapping
+
+`convert.py` uses an explicit mapping rather than deriving Hugging Face names:
+
+| Local scale | Repository | Config | Split |
+| ----------- | ---------- | ------ | ----- |
+| `128k` | `Mohammadta/BEAM` | `default` | `100K` |
+| `500k` | `Mohammadta/BEAM` | `default` | `500K` |
+| `1m` | `Mohammadta/BEAM` | `default` | `1M` |
+| `10m` | `Mohammadta/BEAM-10M` | `default` | `10M` |
+
+Non-sample conversion checks `datasets`, `pyarrow`, arguments, and the output
+path before calling Hugging Face. `sample` never imports those dependencies.
 
 ## Why Python for the conversion?
 

--- a/benchmark/beam/dataset/convert.py
+++ b/benchmark/beam/dataset/convert.py
@@ -21,7 +21,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -50,6 +52,31 @@ BEAM_SOURCES: dict[str, dict[str, str]] = {
 }
 
 SCALES = list(BEAM_SOURCES)
+
+
+def collect_preflight_errors(
+    scale: str,
+    out_dir: Path,
+    max_conversations: int | None,
+) -> list[str]:
+    """Check local requirements before creating files or loading Hugging Face data."""
+    errors: list[str] = []
+    if max_conversations is not None and max_conversations < 1:
+        errors.append("--max-conversations must be a positive integer")
+
+    candidate = out_dir.resolve()
+    while not candidate.exists() and candidate.parent != candidate:
+        candidate = candidate.parent
+    if not candidate.is_dir() or not os.access(candidate, os.W_OK):
+        errors.append(f"output directory is not writable: {out_dir.resolve()}")
+
+    if scale != "sample":
+        for dependency in ("datasets", "pyarrow"):
+            if importlib.util.find_spec(dependency) is None:
+                errors.append(
+                    f"Python dependency missing for non-sample conversion: {dependency}"
+                )
+    return errors
 
 
 def get_beam_source(scale: str) -> dict[str, str]:
@@ -229,6 +256,15 @@ def main() -> None:
         help="Cap on conversations to convert (useful for smoke tests).",
     )
     args = parser.parse_args()
+
+    errors = collect_preflight_errors(args.scale, args.out_dir, args.max_conversations)
+    if errors:
+        print("BEAM conversion preflight failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        raise SystemExit(2)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
 
     scales = SCALES if args.scale == "all" else [args.scale]
     for scale in scales:

--- a/benchmark/beam/dataset/convert.py
+++ b/benchmark/beam/dataset/convert.py
@@ -26,7 +26,39 @@ import sys
 from pathlib import Path
 from typing import Any
 
-SCALES = ["128k", "500k", "1m", "10m"]
+BEAM_SOURCES: dict[str, dict[str, str]] = {
+    "128k": {
+        "repository": "Mohammadta/BEAM",
+        "config": "default",
+        "split": "100K",
+    },
+    "500k": {
+        "repository": "Mohammadta/BEAM",
+        "config": "default",
+        "split": "500K",
+    },
+    "1m": {
+        "repository": "Mohammadta/BEAM",
+        "config": "default",
+        "split": "1M",
+    },
+    "10m": {
+        "repository": "Mohammadta/BEAM-10M",
+        "config": "default",
+        "split": "10M",
+    },
+}
+
+SCALES = list(BEAM_SOURCES)
+
+
+def get_beam_source(scale: str) -> dict[str, str]:
+    """Return the upstream Hugging Face source for a local BEAM scale."""
+    try:
+        return BEAM_SOURCES[scale]
+    except KeyError as error:
+        supported = ", ".join(SCALES)
+        raise ValueError(f"Unknown BEAM scale '{scale}'. Expected one of: {supported}") from error
 
 
 def normalize_turn(turn: dict[str, Any]) -> dict[str, Any]:
@@ -97,17 +129,33 @@ def normalize_conversation(conv: dict[str, Any], idx: int, scale: str) -> dict[s
     }
 
 
-def convert_hf_split(scale: str, out_path: Path, max_conversations: int | None) -> int:
+def convert_hf_split(
+    scale: str,
+    out_path: Path,
+    max_conversations: int | None,
+    load_dataset_fn: Any | None = None,
+) -> int:
     """Download the BEAM parquet for `scale` from HF, normalize, write JSON."""
-    try:
-        from datasets import load_dataset  # type: ignore
-    except ImportError:
-        print("ERROR: `datasets` not installed. Run: pip install datasets pyarrow", file=sys.stderr)
-        sys.exit(1)
+    source = get_beam_source(scale)
+    if load_dataset_fn is None:
+        try:
+            from datasets import load_dataset  # type: ignore
+        except ImportError:
+            print("ERROR: `datasets` not installed. Run: pip install datasets pyarrow", file=sys.stderr)
+            sys.exit(1)
+        load_dataset_fn = load_dataset
 
-    print(f"Loading BEAM/{scale} from HuggingFace…")
-    ds = load_dataset("Mohammadta/BEAM", scale, split="train")
-    print(f"  → {len(ds)} raw rows")
+    print(
+        "Loading "
+        f"{source['repository']} config={source['config']} split={source['split']} "
+        f"for local scale {scale} from HuggingFace..."
+    )
+    ds = load_dataset_fn(
+        source["repository"],
+        source["config"],
+        split=source["split"],
+    )
+    print(f"  -> {len(ds)} raw rows")
 
     out: list[dict[str, Any]] = []
     for i, row in enumerate(ds):
@@ -117,11 +165,11 @@ def convert_hf_split(scale: str, out_path: Path, max_conversations: int | None) 
         if max_conversations is not None and len(out) >= max_conversations:
             break
         if (i + 1) % 50 == 0:
-            print(f"  processed {i + 1} rows, kept {len(out)}…")
+            print(f"  processed {i + 1} rows, kept {len(out)}...")
 
     payload = {"scale": scale, "conversations": out}
     out_path.write_text(json.dumps(payload, ensure_ascii=False))
-    print(f"✅ Wrote {len(out)} conversations → {out_path} ({out_path.stat().st_size / 1_000_000:.1f} MB)")
+    print(f"[ok] Wrote {len(out)} conversations -> {out_path} ({out_path.stat().st_size / 1_000_000:.1f} MB)")
     return len(out)
 
 
@@ -156,12 +204,12 @@ def write_sample(out_path: Path) -> int:
         ],
     }
     out_path.write_text(json.dumps(sample, indent=2, ensure_ascii=False))
-    print(f"✅ Wrote sample → {out_path}")
+    print(f"[ok] Wrote sample -> {out_path}")
     return 1
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Convert BEAM parquet → JSON")
+    parser = argparse.ArgumentParser(description="Convert BEAM parquet to JSON")
     parser.add_argument(
         "--scale",
         choices=SCALES + ["sample", "all"],

--- a/benchmark/beam/dataset/test_convert.py
+++ b/benchmark/beam/dataset/test_convert.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import importlib.util
 import json
 import sys
 import tempfile
@@ -20,6 +21,26 @@ EXPECTED_SOURCES = {
 
 
 class BeamSourceMappingTests(unittest.TestCase):
+    def test_non_sample_preflight_reports_all_missing_dependencies_and_bad_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(importlib.util, "find_spec", return_value=None):
+                errors = convert.collect_preflight_errors("1m", Path(temp_dir), 0)
+
+        self.assertIn("--max-conversations must be a positive integer", errors)
+        self.assertTrue(any("datasets" in error for error in errors))
+        self.assertTrue(any("pyarrow" in error for error in errors))
+
+    def test_sample_preflight_does_not_require_hugging_face_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(
+                importlib.util,
+                "find_spec",
+                side_effect=AssertionError("sample mode must not inspect HF dependencies"),
+            ):
+                errors = convert.collect_preflight_errors("sample", Path(temp_dir), 1)
+
+        self.assertEqual(errors, [])
+
     def test_all_scales_use_the_expected_hugging_face_source(self) -> None:
         fixture = {
             "conversation_id": "fixture-conversation",

--- a/benchmark/beam/dataset/test_convert.py
+++ b/benchmark/beam/dataset/test_convert.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import convert
+
+
+EXPECTED_SOURCES = {
+    "128k": ("Mohammadta/BEAM", "default", "100K"),
+    "500k": ("Mohammadta/BEAM", "default", "500K"),
+    "1m": ("Mohammadta/BEAM", "default", "1M"),
+    "10m": ("Mohammadta/BEAM-10M", "default", "10M"),
+}
+
+
+class BeamSourceMappingTests(unittest.TestCase):
+    def test_all_scales_use_the_expected_hugging_face_source(self) -> None:
+        fixture = {
+            "conversation_id": "fixture-conversation",
+            "chat": [{"role": "user", "content": "Remember Berlin."}],
+            "probing_questions": [
+                {
+                    "id": "fixture-question",
+                    "category": "information_extraction",
+                    "question": "Which city?",
+                    "atoms": ["Berlin"],
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for scale, expected_source in EXPECTED_SOURCES.items():
+                with self.subTest(scale=scale):
+                    calls: list[tuple[str, str, str]] = []
+
+                    def fake_load_dataset(
+                        repository: str,
+                        config: str,
+                        *,
+                        split: str,
+                    ) -> list[dict[str, object]]:
+                        calls.append((repository, config, split))
+                        return [fixture]
+
+                    output = Path(temp_dir) / f"beam_{scale}.json"
+                    converted = convert.convert_hf_split(
+                        scale,
+                        output,
+                        max_conversations=None,
+                        load_dataset_fn=fake_load_dataset,
+                    )
+
+                    self.assertEqual(calls, [expected_source])
+                    self.assertEqual(converted, 1)
+                    payload = json.loads(output.read_text())
+                    self.assertEqual(payload["scale"], scale)
+                    self.assertEqual(payload["conversations"][0]["scale"], scale)
+
+    def test_unknown_scale_fails_before_loading_a_dataset(self) -> None:
+        calls = 0
+
+        def fake_load_dataset(*args: object, **kwargs: object) -> list[object]:
+            nonlocal calls
+            calls += 1
+            return []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, "Unknown BEAM scale '2m'"):
+                convert.convert_hf_split(
+                    "2m",
+                    Path(temp_dir) / "beam_2m.json",
+                    max_conversations=None,
+                    load_dataset_fn=fake_load_dataset,
+                )
+
+        self.assertEqual(calls, 0)
+
+    def test_sample_mode_does_not_import_hugging_face_datasets(self) -> None:
+        real_import = builtins.__import__
+
+        def guarded_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "datasets" or name.startswith("datasets."):
+                raise AssertionError("sample mode must not import datasets")
+            return real_import(name, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.object(builtins, "__import__", side_effect=guarded_import),
+                patch.object(
+                    sys,
+                    "argv",
+                    ["convert.py", "--scale", "sample", "--out-dir", temp_dir],
+                ),
+            ):
+                convert.main()
+
+            payload = json.loads(
+                (Path(temp_dir) / "sample_conversation.json").read_text()
+            )
+            self.assertEqual(payload["scale"], "sample")
+            self.assertEqual(len(payload["conversations"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/beam/package.json
+++ b/benchmark/beam/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"
 	},

--- a/benchmark/beam/src/evaluator.ts
+++ b/benchmark/beam/src/evaluator.ts
@@ -19,6 +19,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { sumTokenUsage, unavailableTokenUsage, zeroTokenUsage } from "../../run-support";
 import {
 	type NuggetJudgeResult,
 	evaluateNuggetJudge,
@@ -268,17 +269,22 @@ export class BeamEvaluator {
 			return checkpoint;
 		}
 
+		let answerUsage = unavailableTokenUsage();
+		let judgeUsage = unavailableTokenUsage();
 		try {
 			const hits = await searchMemory(question.question, RETRIEVAL_LIMIT, this.baseUrl, beamUserId(conv));
 			const prompt = buildAnswerPrompt(conv, question, hits);
-			const response = await generateAnswer(prompt);
+			const answerResult = await generateAnswer(prompt);
+			answerUsage = answerResult.token_usage;
+			const response = answerResult.text;
+			if (!response.trim()) throw new Error("answerer returned an empty response");
 
 			const abstained = looksLikeAbstention(response);
 
 			let judgeResult: NuggetJudgeResult;
 			if (question.atoms.length === 0) {
 				console.warn(`[BEAM] Question ${question.question_id} has no atoms — using empty judge result`);
-				judgeResult = { scores: [], reasoning: "no atoms" };
+				judgeResult = { scores: [], reasoning: "no atoms", token_usage: zeroTokenUsage() };
 			} else {
 				judgeResult = await evaluateNuggetJudge(
 					question.question,
@@ -287,10 +293,12 @@ export class BeamEvaluator {
 					response,
 				);
 			}
+			judgeUsage = judgeResult.token_usage;
 
 			const { nugget_mean, nugget_pass } = summarizeNuggetScores(judgeResult.scores);
 
 			const pred: Prediction = {
+				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 				question_id: question.question_id,
 				question: question.question,
 				response,
@@ -318,6 +326,7 @@ export class BeamEvaluator {
 
 			const emptyScores: number[] = question.atoms.map(() => 0);
 			const pred: Prediction = {
+				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 				question_id: question.question_id,
 				question: question.question,
 				response: `Error: ${errorMessage}`,

--- a/benchmark/beam/src/index.ts
+++ b/benchmark/beam/src/index.ts
@@ -13,11 +13,27 @@
  */
 
 import "dotenv/config";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import {
+	getManifestPath,
+	runPreflight,
+	sumTokenUsage,
+	unavailableTokenUsage,
+	writeRunManifest,
+} from "../../run-support";
 import { expandBeamSamples, loadBeamDatasetFromJson } from "./dataset";
-import { BeamEvaluator } from "./evaluator";
-import { type NuggetCategoryMetrics, calculateNuggetCategoryMetrics } from "./metrics";
-import { checkOpencontextHealth, getOpencontextBaseUrl } from "./opencontext-client";
+import { BeamEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
+import {
+	JUDGE_MODEL,
+	type NuggetCategoryMetrics,
+	calculateNuggetCategoryMetrics,
+} from "./metrics";
+import {
+	checkOpencontextHealth,
+	getAnswererModelIdentity,
+	getOpencontextBaseUrl,
+} from "./opencontext-client";
 import {
 	OPENCONTEXT_CLAIM_MAP,
 	OPENCONTEXT_HIGHLIGHT_CATEGORIES,
@@ -36,20 +52,25 @@ interface CliArgs {
 	output?: string;
 	port?: number;
 	resume: boolean;
+	parameterErrors: string[];
 }
 
-function parseCsv<T extends string>(raw: string | undefined, valid?: Set<T>): T[] | undefined {
+function parseCsv<T extends string>(
+	raw: string | undefined,
+	valid: Set<T>,
+	option: string,
+	errors: string[],
+): T[] | undefined {
 	if (!raw) return undefined;
 	const parts = raw
 		.split(",")
 		.map((s) => s.trim())
 		.filter((s) => s.length > 0);
 	if (parts.length === 0) return undefined;
-	if (!valid) return parts as T[];
 	const out: T[] = [];
 	for (const part of parts) {
 		if (!valid.has(part as T)) {
-			console.error(`Unknown value: ${part}`);
+			errors.push(`${option} contains an unknown value: ${part}`);
 			continue;
 		}
 		out.push(part as T);
@@ -99,6 +120,7 @@ function parseCliArgs(): CliArgs {
 
 	const typeSet = new Set<BeamQuestionCategory>(QUESTION_TYPES);
 	const scaleSet = new Set<BeamScale>(["128k", "500k", "1m", "10m"]);
+	const parameterErrors: string[] = [];
 
 	const conversations = values.conversations
 		? Number.parseInt(values.conversations as string, 10)
@@ -109,15 +131,15 @@ function parseCliArgs(): CliArgs {
 
 	return {
 		dataset: values.dataset as string,
-		conversations: conversations !== undefined && Number.isFinite(conversations) ? conversations : undefined,
-		questionsPerConv:
-			questionsPerConv !== undefined && Number.isFinite(questionsPerConv) ? questionsPerConv : undefined,
-		types: parseCsv<BeamQuestionCategory>(values.types as string, typeSet),
-		scale: parseCsv<BeamScale>(values.scale as string, scaleSet)?.[0],
+		conversations,
+		questionsPerConv,
+		types: parseCsv<BeamQuestionCategory>(values.types as string, typeSet, "--type", parameterErrors),
+		scale: parseCsv<BeamScale>(values.scale as string, scaleSet, "--scale", parameterErrors)?.[0],
 		quick: values.quick as boolean,
 		output: values.output as string | undefined,
 		port: values.port ? Number.parseInt(values.port as string, 10) : undefined,
 		resume: values.resume !== false,
+		parameterErrors,
 	};
 }
 
@@ -231,32 +253,56 @@ function printSummary(
 }
 
 async function main() {
+	const startedAt = new Date().toISOString();
 	const args = parseCliArgs();
-
-	// Resolve the OpenContext memory daemon and verify it is up
 	const baseUrl = args.port ? `http://127.0.0.1:${args.port}` : getOpencontextBaseUrl();
-	try {
-		await checkOpencontextHealth(baseUrl);
-		console.log(`🔌 OpenContext memory daemon: ${baseUrl}`);
-	} catch (error) {
-		console.error(`${error}`);
-		process.exit(1);
+	const benchmarkDir = join(import.meta.dirname, "..");
+	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
+	let conversations: Awaited<ReturnType<typeof loadBeamDatasetFromJson>> = [];
+	let activeSamples: ReturnType<typeof expandBeamSamples> = [];
+	if (
+		args.conversations !== undefined &&
+		(!Number.isInteger(args.conversations) || args.conversations < 1)
+	) {
+		args.parameterErrors.push("--conversations must be a positive integer");
+	}
+	if (
+		args.questionsPerConv !== undefined &&
+		(!Number.isInteger(args.questionsPerConv) || args.questionsPerConv < 1)
+	) {
+		args.parameterErrors.push("--questions-per-conv must be a positive integer");
+	}
+	if (args.port !== undefined && (!Number.isInteger(args.port) || args.port < 1 || args.port > 65_535)) {
+		args.parameterErrors.push("--port must be an integer between 1 and 65535");
 	}
 
-	console.log(`\n📁 Loading dataset from: ${args.dataset}`);
-	const conversations = await loadBeamDatasetFromJson(args.dataset, {
-		conversations: args.conversations,
-		questionsPerConv: args.questionsPerConv,
-		types: args.types,
-		assertScale: args.scale,
+	await runPreflight({
+		datasetPath: args.dataset,
+		writablePaths: [
+			manifestPath,
+			join(benchmarkDir, "checkpoints", "beam", ".preflight"),
+			...(args.output ? [args.output] : []),
+		],
+		parameterErrors: args.parameterErrors,
+		validateDataset: async () => {
+			conversations = await loadBeamDatasetFromJson(args.dataset, {
+				conversations: args.conversations,
+				questionsPerConv: args.questionsPerConv,
+				types: args.types,
+				assertScale: args.scale,
+			});
+			activeSamples = expandBeamSamples(conversations);
+			if (args.quick) activeSamples = activeSamples.slice(0, 5);
+			if (conversations.length === 0 || activeSamples.length === 0) {
+				throw new Error(
+					"no questions remain after applying --type/--scale/--conversations/--questions-per-conv",
+				);
+			}
+		},
+		checkDaemon: () => checkOpencontextHealth(baseUrl),
 	});
-
-	if (conversations.length === 0) {
-		console.error(
-			"❌ No conversations remaining after filtering. Check your --type / --conversations / --questions-per-conv flags.",
-		);
-		process.exit(1);
-	}
+	console.log(`🔌 OpenContext memory daemon: ${baseUrl}`);
+	console.log(`\n📁 Loaded dataset from: ${args.dataset}`);
 
 	console.log(`📊 Loaded ${conversations.length} BEAM conversations`);
 	if (args.types) {
@@ -264,10 +310,7 @@ async function main() {
 	}
 	console.log();
 
-	const samples = expandBeamSamples(conversations);
-	let activeSamples = samples;
 	if (args.quick) {
-		activeSamples = samples.slice(0, 5);
 		console.log(`⚡ Quick mode: limiting to first ${activeSamples.length} questions`);
 	}
 	console.log(`🎯 Evaluating ${activeSamples.length} questions\n`);
@@ -305,6 +348,7 @@ async function main() {
 			console.error(`Error on ${sample.question.question_id}: ${errorMessage}`);
 
 			const failedPred: Prediction = {
+				token_usage: unavailableTokenUsage(),
 				question_id: sample.question.question_id,
 				question: sample.question.question,
 				response: `Error: ${errorMessage}`,
@@ -341,11 +385,7 @@ async function main() {
 					correct_answers: 0,
 					nugget_mean: 0,
 					nugget_pass_rate: 0,
-					token_usage: {
-						prompt_tokens: 0,
-						completion_tokens: 0,
-						total_tokens: 0,
-					},
+					token_usage: unavailableTokenUsage(),
 					predictions: [],
 				});
 			}
@@ -360,15 +400,39 @@ async function main() {
 		const m = calculateNuggetCategoryMetrics(entry.predictions);
 		entry.nugget_mean = m.nugget_mean;
 		entry.nugget_pass_rate = m.nugget_pass_rate;
+		entry.token_usage = sumTokenUsage(entry.predictions.map((prediction) => prediction.token_usage));
 	}
 
+	const predictions = Object.values(predictionsByCategory).flat();
+	const runTokenUsage = sumTokenUsage(predictions.map((prediction) => prediction.token_usage));
+	const finishedAt = new Date().toISOString();
+	const runManifest = await writeRunManifest(manifestPath, {
+		benchmark: "beam",
+		datasetPath: args.dataset,
+		answerer_model: getAnswererModelIdentity(),
+		judge_model: JUDGE_MODEL,
+		retrieval: { strategy: "memory-search", top_k: RETRIEVAL_LIMIT },
+		resume: args.resume,
+		started_at: startedAt,
+		finished_at: finishedAt,
+		token_usage: runTokenUsage,
+		parameters: {
+			conversations: args.conversations ?? null,
+			questions_per_conversation: args.questionsPerConv ?? null,
+			categories: args.types ?? null,
+			scale: args.scale ?? null,
+			quick: args.quick ?? false,
+		},
+	});
 	const output = {
 		dataset: args.dataset,
 		scale: args.scale,
 		conversations_run: conversations.length,
 		questions_run: activeSamples.length,
 		categories_filter: args.types ?? null,
-		summary: calculateNuggetCategoryMetrics(Object.values(predictionsByCategory).flat()),
+		summary: calculateNuggetCategoryMetrics(predictions),
+		token_usage: runTokenUsage,
+		run_manifest: runManifest,
 		per_category: Object.fromEntries(
 			QUESTION_TYPES.filter((c) => predictionsByCategory[c].length > 0).map((c) => [
 				c,
@@ -379,13 +443,15 @@ async function main() {
 			]),
 		),
 		per_entry: Array.from(perEntry.values()),
-		predictions: Object.values(predictionsByCategory).flat(),
+		predictions,
 	};
 
 	if (args.output) {
+		await mkdir(dirname(resolve(args.output)), { recursive: true });
 		await writeFile(args.output, JSON.stringify(output, null, 2), "utf-8");
 		console.log(`💾 Results saved to: ${args.output}`);
 	}
+	console.log(`🧾 Run manifest saved to: ${manifestPath}`);
 
 	return output;
 }

--- a/benchmark/beam/src/index.ts
+++ b/benchmark/beam/src/index.ts
@@ -24,11 +24,7 @@ import {
 } from "../../run-support";
 import { expandBeamSamples, loadBeamDatasetFromJson } from "./dataset";
 import { BeamEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
-import {
-	JUDGE_MODEL,
-	type NuggetCategoryMetrics,
-	calculateNuggetCategoryMetrics,
-} from "./metrics";
+import { JUDGE_MODEL, type NuggetCategoryMetrics, calculateNuggetCategoryMetrics } from "./metrics";
 import {
 	checkOpencontextHealth,
 	getAnswererModelIdentity,
@@ -260,10 +256,7 @@ async function main() {
 	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
 	let conversations: Awaited<ReturnType<typeof loadBeamDatasetFromJson>> = [];
 	let activeSamples: ReturnType<typeof expandBeamSamples> = [];
-	if (
-		args.conversations !== undefined &&
-		(!Number.isInteger(args.conversations) || args.conversations < 1)
-	) {
+	if (args.conversations !== undefined && (!Number.isInteger(args.conversations) || args.conversations < 1)) {
 		args.parameterErrors.push("--conversations must be a positive integer");
 	}
 	if (

--- a/benchmark/beam/src/metrics.ts
+++ b/benchmark/beam/src/metrics.ts
@@ -8,12 +8,7 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
-import {
-	tokenUsage,
-	type TokenUsage,
-	unavailableTokenUsage,
-	zeroTokenUsage,
-} from "../../run-support";
+import { tokenUsage, type TokenUsage, unavailableTokenUsage, zeroTokenUsage } from "../../run-support";
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
 	apiKey: process.env.OPENROUTER_API_KEY,

--- a/benchmark/beam/src/metrics.ts
+++ b/benchmark/beam/src/metrics.ts
@@ -8,6 +8,12 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
+import {
+	tokenUsage,
+	type TokenUsage,
+	unavailableTokenUsage,
+	zeroTokenUsage,
+} from "../../run-support";
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
 	apiKey: process.env.OPENROUTER_API_KEY,
@@ -113,7 +119,10 @@ export function calculateBLEUScores(
 export interface NuggetJudgeResult {
 	scores: number[];
 	reasoning: string;
+	token_usage: TokenUsage;
 }
+
+export const JUDGE_MODEL = "qwen/qwen3.7-max";
 
 /**
  * Normalize a raw judge score into the BEAM rubric's {0.0, 0.5, 1.0} set.
@@ -186,7 +195,7 @@ export async function evaluateNuggetJudge(
 	maxRetries = 3,
 ): Promise<NuggetJudgeResult> {
 	if (atoms.length === 0) {
-		return { scores: [], reasoning: "no atoms" };
+		return { scores: [], reasoning: "no atoms", token_usage: zeroTokenUsage() };
 	}
 
 	const prompt = BEAM_NUGGET_JUDGE_PROMPT.replace("{category}", category)
@@ -198,8 +207,8 @@ export async function evaluateNuggetJudge(
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
-			const { text } = await generateText({
-				model: openrouter("qwen/qwen3.7-max"),
+			const { text, usage } = await generateText({
+				model: openrouter(JUDGE_MODEL),
 				system: "You are an impartial judge scoring answers to questions. Always respond with valid JSON.",
 				prompt,
 			});
@@ -228,6 +237,7 @@ export async function evaluateNuggetJudge(
 				return {
 					scores,
 					reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : "(no reasoning)",
+					token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
 				};
 			}
 		} catch (error) {
@@ -243,6 +253,7 @@ export async function evaluateNuggetJudge(
 	return {
 		scores: atoms.map(() => 0),
 		reasoning: `judge failure: ${lastError?.message ?? "unknown"}`,
+		token_usage: unavailableTokenUsage(),
 	};
 }
 

--- a/benchmark/beam/src/opencontext-client.ts
+++ b/benchmark/beam/src/opencontext-client.ts
@@ -12,6 +12,8 @@
  * (OPENROUTER_API_KEY, OPENROUTER_ANSWER_MODEL).
  */
 
+import { tokenUsage, type TokenUsage } from "../../run-support";
+
 export const DEFAULT_OPENCONTEXT_PORT = 7421;
 
 export function getOpencontextBaseUrl(): string {
@@ -21,6 +23,18 @@ export function getOpencontextBaseUrl(): string {
 }
 
 export const BENCH_USER_ID = "benchmark_user";
+
+export function getAnswererModelIdentity(): string {
+	if (process.env.ANTHROPIC_AUTH_TOKEN) {
+		return `anthropic-compatible:${process.env.ANSWER_MODEL ?? "MiniMax-M3-highspeed"}`;
+	}
+	return `openrouter:${process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"}`;
+}
+
+export interface GeneratedAnswer {
+	text: string;
+	token_usage: TokenUsage;
+}
 
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
 	let res: Response;
@@ -136,7 +150,7 @@ export async function searchMemory(
  * Fallback: OpenRouter chat completions:
  *   OPENROUTER_API_KEY / OPENROUTER_ANSWER_MODEL (default deepseek/deepseek-chat)
  */
-export async function generateAnswer(prompt: string, system?: string): Promise<string> {
+export async function generateAnswer(prompt: string, system?: string): Promise<GeneratedAnswer> {
 	const token = process.env.ANTHROPIC_AUTH_TOKEN;
 	if (token) {
 		const base = (process.env.ANTHROPIC_BASE_URL ?? "https://api.minimaxi.com/anthropic").replace(/\/+$/, "");
@@ -161,12 +175,16 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		}
 		const data = (await res.json()) as {
 			content?: Array<{ type: string; text?: string }>;
+			usage?: { input_tokens?: number; output_tokens?: number };
 		};
 		const text = (data.content ?? [])
 			.filter((b) => b.type === "text" && typeof b.text === "string")
 			.map((b) => b.text as string)
 			.join("");
-		return text || "(empty response)";
+		return {
+			text,
+			token_usage: tokenUsage(data.usage?.input_tokens, data.usage?.output_tokens, undefined),
+		};
 	}
 
 	const openrouterKey = process.env.OPENROUTER_API_KEY;
@@ -180,10 +198,13 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		apiKey: openrouterKey,
 		name: "openrouter",
 	});
-	const { text } = await generateText({
+	const { text, usage } = await generateText({
 		model: openrouter(process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"),
 		...(system ? { system } : {}),
 		prompt,
 	});
-	return text;
+	return {
+		text,
+		token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+	};
 }

--- a/benchmark/beam/src/types.ts
+++ b/benchmark/beam/src/types.ts
@@ -5,6 +5,8 @@
  * 10 question categories across 4 buckets (128K / 500K / 1M / 10M).
  */
 
+import type { TokenUsage } from "../../run-support";
+
 export type BeamScale = "128k" | "500k" | "1m" | "10m";
 
 export type BeamQuestionCategory =
@@ -105,11 +107,7 @@ export interface EvaluationResult {
 	 * Fraction of questions with nugget_mean >= 0.5.
 	 */
 	nugget_pass_rate: number;
-	token_usage: {
-		prompt_tokens: number;
-		completion_tokens: number;
-		total_tokens: number;
-	};
+	token_usage: TokenUsage;
 	predictions: Prediction[];
 	error?: string;
 }
@@ -118,6 +116,7 @@ export interface EvaluationResult {
  * Prediction result for a single question.
  */
 export interface Prediction {
+	token_usage: TokenUsage;
 	question_id: string;
 	question: string;
 	response: string;

--- a/benchmark/beam/tsconfig.json
+++ b/benchmark/beam/tsconfig.json
@@ -1,6 +1,7 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"incremental": false,
 		"outDir": "./dist",
 		"rootDir": "./src"
 	},

--- a/benchmark/beam/tsconfig.json
+++ b/benchmark/beam/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"incremental": false,
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": ".."
 	},
 	"include": ["src/**/*"]
 }

--- a/benchmark/locomo/README.md
+++ b/benchmark/locomo/README.md
@@ -97,6 +97,16 @@ pnpm benchmark -- --dataset dataset/locomo_v2.json --mode observation --output r
 | `--quick`   | `-q`  | Limit to first 5 questions per sample               | false              |
 | `--output`  | `-o`  | Save results JSON to path                           | None               |
 | `--port`    | `-p`  | OpenContext daemon port (env: `OPENCONTEXT_PORT` / `OPENCONTEXT_URL`) | 7421 |
+| `--resume`  |       | Reuse completed checkpoints for the same models    | true               |
+| `--no-resume` |     | Ignore checkpoints and run every selected question | false              |
+
+Before ingest or model calls, the CLI checks the dataset and selected samples,
+daemon, credentials, output/checkpoint paths, and arguments. It reports all
+detected failures together and never prints credential values. `--help` does not
+run these checks.
+
+With `--resume`, both correct and incorrect completed judge results are reused;
+only execution failures are retried. `--no-resume` always starts a fresh run.
 
 ## Output
 
@@ -105,7 +115,12 @@ The benchmark outputs:
 - **Overall accuracy** - LLM judge accuracy across all categories
 - **Per-category metrics** - F1, BLEU-1, BLEU-4 scores by category
 - **Per-sample results** - Accuracy and token usage per sample
-- **Token totals** - Combined API token consumption
+- **Token usage** - Real provider usage when available; otherwise `null`
+- **Run manifest** - Git commit, dataset identity, models, retrieval mode/top-k,
+  selection parameters, resume mode, and wall-clock time
+
+With `--output results.json`, the manifest is written to
+`results.json.manifest.json`. Without `--output`, it is written under `results/`.
 
 ### Metrics
 

--- a/benchmark/locomo/package.json
+++ b/benchmark/locomo/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"
 	},

--- a/benchmark/locomo/package.json
+++ b/benchmark/locomo/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"

--- a/benchmark/locomo/src/evaluator.test.ts
+++ b/benchmark/locomo/src/evaluator.test.ts
@@ -1,0 +1,195 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./opencontext-client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./opencontext-client")>();
+	return {
+		...actual,
+		generateAnswer: vi.fn(),
+		searchMemory: vi.fn(),
+	};
+});
+
+vi.mock("./metrics", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./metrics")>();
+	return {
+		...actual,
+		evaluateLLMJudge: vi.fn(),
+	};
+});
+
+import { LoCoMoEvaluator } from "./evaluator";
+import { JUDGE_MODEL, evaluateLLMJudge, parseLLMJudgeResponse } from "./metrics";
+import { generateAnswer, searchMemory } from "./opencontext-client";
+import type { LoCoMoSample } from "./types";
+
+const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+const originalAnswerModel = process.env.ANSWER_MODEL;
+const temporaryDirectories: string[] = [];
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}
+
+async function createCheckpointDir(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "opencontext-locomo-checkpoint-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function createEvaluator(checkpointDir: string, resume = true): LoCoMoEvaluator {
+	const evaluator = new LoCoMoEvaluator("observation", "http://fixture.invalid", undefined, resume);
+	Object.assign(evaluator, { checkpointDir, ingestedCount: 1 });
+	return evaluator;
+}
+
+function createSample(questionCount = 1): LoCoMoSample {
+	return {
+		sample_id: "fixture-sample",
+		conversation: {},
+		observation: {},
+		session_summary: {},
+		event_summary: {},
+		qa_pairs: Array.from({ length: questionCount }, (_, index) => ({
+			question: `Question ${index + 1}?`,
+			answer: `Answer ${index + 1}`,
+			category: 1,
+			evidence: [],
+		})),
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env.ANTHROPIC_AUTH_TOKEN = "fixture-token";
+	process.env.ANSWER_MODEL = "answerer-a";
+	vi.mocked(searchMemory).mockResolvedValue([]);
+	vi.mocked(generateAnswer).mockResolvedValue("fixture response");
+});
+
+afterEach(async () => {
+	restoreEnvironment("ANTHROPIC_AUTH_TOKEN", originalAuthToken);
+	restoreEnvironment("ANSWER_MODEL", originalAnswerModel);
+	await Promise.all(
+		temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+describe("LoCoMo checkpoint resume", () => {
+	it("reuses both correct and incorrect completed results across repeated resumes", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const sample = createSample(2);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+
+		const first = await createEvaluator(checkpointDir).evaluateQA(sample);
+		expect(first.correct_answers).toBe(1);
+		expect(first.predictions.map((prediction) => prediction.status)).toEqual(["completed", "completed"]);
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockClear();
+		const second = await createEvaluator(checkpointDir).evaluateQA(sample);
+		const third = await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		expect(generateAnswer).not.toHaveBeenCalled();
+		expect(evaluateLLMJudge).not.toHaveBeenCalled();
+		expect(second.correct_answers).toBe(1);
+		expect(third.correct_answers).toBe(1);
+		expect(second.predictions.map((prediction) => prediction.correct)).toEqual([true, false]);
+	});
+
+	it("retries execution errors and increments the attempt", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const sample = createSample();
+		vi.mocked(evaluateLLMJudge).mockRejectedValueOnce(new Error("judge parse failure"));
+
+		const failed = await createEvaluator(checkpointDir).evaluateQA(sample);
+		expect(failed.predictions[0]).toMatchObject({
+			status: "execution_error",
+			attempt: 1,
+			error: "judge parse failure",
+		});
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		const retried = await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(retried.predictions[0]).toMatchObject({ status: "completed", attempt: 2, correct: false });
+	});
+
+	it("ignores existing checkpoints when resume is disabled", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const sample = createSample();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		const fresh = await createEvaluator(checkpointDir, false).evaluateQA(sample);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(fresh.predictions[0]).toMatchObject({ status: "completed", attempt: 1, correct: true });
+	});
+
+	it("does not reuse a checkpoint from a different answerer or judge model", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const sample = createSample();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		process.env.ANSWER_MODEL = "answerer-b";
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		const rerun = await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(rerun.predictions[0]).toMatchObject({
+			status: "completed",
+			attempt: 2,
+			answerer_model: "anthropic-compatible:answerer-b",
+		});
+
+		const checkpointPath = join(checkpointDir, "fixture-sample.json");
+		const checkpoint = JSON.parse(await readFile(checkpointPath, "utf-8")) as Record<
+			string,
+			Record<string, unknown>
+		>;
+		checkpoint["0"].judge_model = "different-judge";
+		await writeFile(checkpointPath, JSON.stringify(checkpoint), "utf-8");
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		const judgeRerun = await createEvaluator(checkpointDir).evaluateQA(sample);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(judgeRerun.predictions[0]).toMatchObject({
+			status: "completed",
+			attempt: 3,
+			judge_model: JUDGE_MODEL,
+		});
+	});
+
+	it("records an empty answer as an execution error without calling the judge", async () => {
+		const checkpointDir = await createCheckpointDir();
+		vi.mocked(generateAnswer).mockResolvedValueOnce("");
+
+		const result = await createEvaluator(checkpointDir).evaluateQA(createSample());
+
+		expect(evaluateLLMJudge).not.toHaveBeenCalled();
+		expect(result.predictions[0]).toMatchObject({
+			status: "execution_error",
+			error: "Answerer returned an empty response",
+		});
+	});
+});
+
+describe("LoCoMo judge parsing", () => {
+	it("accepts explicit labels and rejects an unparseable response", () => {
+		expect(parseLLMJudgeResponse('{"label":"CORRECT"}')).toBe(1);
+		expect(parseLLMJudgeResponse("WRONG")).toBe(0);
+		expect(() => parseLLMJudgeResponse("unknown")).toThrow("could not be parsed");
+	});
+});

--- a/benchmark/locomo/src/evaluator.test.ts
+++ b/benchmark/locomo/src/evaluator.test.ts
@@ -28,6 +28,11 @@ import type { LoCoMoSample } from "./types";
 const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
 const originalAnswerModel = process.env.ANSWER_MODEL;
 const temporaryDirectories: string[] = [];
+const fixtureUsage = { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 };
+
+function judgeResult(score: number) {
+	return { score, token_usage: fixtureUsage };
+}
 
 function restoreEnvironment(name: string, value: string | undefined): void {
 	if (value === undefined) delete process.env[name];
@@ -67,7 +72,7 @@ beforeEach(() => {
 	process.env.ANTHROPIC_AUTH_TOKEN = "fixture-token";
 	process.env.ANSWER_MODEL = "answerer-a";
 	vi.mocked(searchMemory).mockResolvedValue([]);
-	vi.mocked(generateAnswer).mockResolvedValue("fixture response");
+	vi.mocked(generateAnswer).mockResolvedValue({ text: "fixture response", token_usage: fixtureUsage });
 });
 
 afterEach(async () => {
@@ -82,10 +87,11 @@ describe("LoCoMo checkpoint resume", () => {
 	it("reuses both correct and incorrect completed results across repeated resumes", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const sample = createSample(2);
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1)).mockResolvedValueOnce(judgeResult(0));
 
 		const first = await createEvaluator(checkpointDir).evaluateQA(sample);
 		expect(first.correct_answers).toBe(1);
+		expect(first.token_usage).toEqual({ prompt_tokens: 40, completion_tokens: 20, total_tokens: 60 });
 		expect(first.predictions.map((prediction) => prediction.status)).toEqual(["completed", "completed"]);
 
 		vi.mocked(generateAnswer).mockClear();
@@ -113,7 +119,7 @@ describe("LoCoMo checkpoint resume", () => {
 		});
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		const retried = await createEvaluator(checkpointDir).evaluateQA(sample);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -123,11 +129,11 @@ describe("LoCoMo checkpoint resume", () => {
 	it("ignores existing checkpoints when resume is disabled", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const sample = createSample();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		await createEvaluator(checkpointDir).evaluateQA(sample);
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1));
 		const fresh = await createEvaluator(checkpointDir, false).evaluateQA(sample);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -137,12 +143,12 @@ describe("LoCoMo checkpoint resume", () => {
 	it("does not reuse a checkpoint from a different answerer or judge model", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const sample = createSample();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		await createEvaluator(checkpointDir).evaluateQA(sample);
 
 		process.env.ANSWER_MODEL = "answerer-b";
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1));
 		const rerun = await createEvaluator(checkpointDir).evaluateQA(sample);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -161,7 +167,7 @@ describe("LoCoMo checkpoint resume", () => {
 		await writeFile(checkpointPath, JSON.stringify(checkpoint), "utf-8");
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		const judgeRerun = await createEvaluator(checkpointDir).evaluateQA(sample);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -174,7 +180,7 @@ describe("LoCoMo checkpoint resume", () => {
 
 	it("records an empty answer as an execution error without calling the judge", async () => {
 		const checkpointDir = await createCheckpointDir();
-		vi.mocked(generateAnswer).mockResolvedValueOnce("");
+		vi.mocked(generateAnswer).mockResolvedValueOnce({ text: "", token_usage: fixtureUsage });
 
 		const result = await createEvaluator(checkpointDir).evaluateQA(createSample());
 

--- a/benchmark/locomo/src/evaluator.ts
+++ b/benchmark/locomo/src/evaluator.ts
@@ -9,17 +9,18 @@
  *   2. evaluateQA: retrieve relevant memories (`POST /v1/search`), then ask
  *      the answerer LLM (see opencontext-client.ts) using only the retrieved
  *      excerpts.
- *   3. Judge unchanged (metrics.ts, OpenRouter).
+ *   3. Judge with the existing metrics.ts model and prompt (OpenRouter).
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { calculateMetrics, evaluateLLMJudge } from "./metrics";
+import { JUDGE_MODEL, calculateMetrics, evaluateLLMJudge } from "./metrics";
 import {
 	type BenchRawMessage,
 	type MemorySearchHit,
 	generateAnswer,
+	getAnswererModelIdentity,
 	getOpencontextBaseUrl,
 	ingestMessages,
 	searchMemory,
@@ -29,6 +30,18 @@ import type { EvaluationResult, LoCoMoSample, Prediction, QAPair } from "./types
 
 /** How many retrieved memories are shown to the answerer. */
 export const RETRIEVAL_LIMIT = 8;
+
+function isReusableCheckpoint(
+	prediction: Prediction | undefined,
+	answererModel: string,
+	judgeModel: string,
+): boolean {
+	return (
+		prediction?.status === "completed" &&
+		prediction.answerer_model === answererModel &&
+		prediction.judge_model === judgeModel
+	);
+}
 
 /**
  * Parse timestamp string to Unix ms.
@@ -423,37 +436,30 @@ export class LoCoMoEvaluator {
 			};
 		}
 
-		// Load checkpoint for resume support
 		const checkpoint = (await this.loadCheckpoint(sample.sample_id)) || {};
-
-		// Separate passed vs failed questions - only re-evaluate failed ones
-		const passedIndices = new Set<number>();
-		const failedIndices = new Set<number>();
+		const answererModel = getAnswererModelIdentity();
+		const judgeModel = JUDGE_MODEL;
+		const reusableIndices = new Set<number>();
+		let executionErrorsToRetry = 0;
+		let incompatibleCheckpoints = 0;
 
 		for (const [idx, pred] of Object.entries(checkpoint)) {
 			const i = Number(idx);
-			if (pred.correct) {
-				passedIndices.add(i);
+			if (isReusableCheckpoint(pred, answererModel, judgeModel)) {
+				reusableIndices.add(i);
+			} else if (pred?.status === "execution_error") {
+				executionErrorsToRetry++;
 			} else {
-				failedIndices.add(i);
+				incompatibleCheckpoints++;
 			}
 		}
-
-		const skippedCount = passedIndices.size;
-		const retriedCount = failedIndices.size;
 
 		const predictions: Prediction[] = [];
 		let correct = 0;
 
-		// If we have checkpoint data, restore predictions for passed questions
-		if (skippedCount > 0) {
-			for (const i of passedIndices) {
-				const pred = checkpoint[i];
-				predictions.push(pred);
-				correct++;
-			}
+		if (Object.keys(checkpoint).length > 0) {
 			console.log(
-				`[LoCoMo] Resuming from checkpoint: ${skippedCount} passed (skipping), ${retriedCount} failed (retrying)`,
+				`[LoCoMo] Resume: ${reusableIndices.size} completed result(s) reused, ${executionErrorsToRetry} execution error(s) retrying, ${incompatibleCheckpoints} legacy/model-mismatched result(s) re-running`,
 			);
 		}
 
@@ -467,28 +473,25 @@ export class LoCoMoEvaluator {
 		for (let i = 0; i < questionsToEvaluate.length; i++) {
 			const qa = questionsToEvaluate[i];
 
-			// Skip if already passed (from checkpoint) - only re-evaluate failed ones
-			if (passedIndices.has(i)) {
+			const existing = checkpoint[i];
+			if (reusableIndices.has(i)) {
+				predictions.push(existing);
+				if (existing.correct) correct++;
 				continue;
 			}
+			const attempt = (existing?.attempt ?? 0) + 1;
 
 			try {
 				// Retrieve relevant memories, then answer using only those excerpts
 				const response = await this.answerQuestion(qa, sample);
 
 				// Evaluate answer correctness using LLM judge
-				let isCorrect = false;
-				try {
-					isCorrect = (await evaluateLLMJudge(qa.question, qa.answer, response)) === 1;
-					console.log(
-						`[Q${i + 1}] ${isCorrect ? "✓" : "✗"} Q: "${qa.question.substring(0, 60)}..." GT: "${qa.answer}"`,
-					);
-					if (!isCorrect) {
-						console.log(`    Agent response: "${response.substring(0, 300)}..."`);
-					}
-				} catch (judgeError) {
-					const errMsg = judgeError instanceof Error ? judgeError.message : String(judgeError);
-					console.log(`[Q${i + 1}] ✗ Judge failed: ${errMsg.substring(0, 100)}`);
+				const isCorrect = (await evaluateLLMJudge(qa.question, qa.answer, response)) === 1;
+				console.log(
+					`[Q${i + 1}] ${isCorrect ? "✓" : "✗"} Q: "${qa.question.substring(0, 60)}..." GT: "${qa.answer}"`,
+				);
+				if (!isCorrect) {
+					console.log(`    Agent response: "${response.substring(0, 300)}..."`);
 				}
 
 				if (isCorrect) {
@@ -499,6 +502,10 @@ export class LoCoMoEvaluator {
 				const metrics = calculateMetrics(response, qa.answer);
 
 				const pred: Prediction = {
+					status: "completed",
+					attempt,
+					answerer_model: answererModel,
+					judge_model: judgeModel,
 					question: qa.question,
 					answer: qa.answer,
 					response,
@@ -529,6 +536,11 @@ export class LoCoMoEvaluator {
 				);
 
 				const pred: Prediction = {
+					status: "execution_error",
+					attempt,
+					answerer_model: answererModel,
+					judge_model: judgeModel,
+					error: errorMessage,
 					question: qa.question,
 					answer: qa.answer,
 					response: `Error: ${errorMessage}`,
@@ -577,6 +589,10 @@ export class LoCoMoEvaluator {
 	private async answerQuestion(qa: QAPair, sample: LoCoMoSample): Promise<string> {
 		const hits = await searchMemory(qa.question, RETRIEVAL_LIMIT, this.baseUrl, `locomo_${sample.sample_id}`);
 		const prompt = buildAnswerPrompt(qa, sample, hits);
-		return await generateAnswer(prompt);
+		const response = await generateAnswer(prompt);
+		if (!response.trim() || response === "(empty response)") {
+			throw new Error("Answerer returned an empty response");
+		}
+		return response;
 	}
 }

--- a/benchmark/locomo/src/evaluator.ts
+++ b/benchmark/locomo/src/evaluator.ts
@@ -15,9 +15,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { sumTokenUsage, unavailableTokenUsage } from "../../run-support";
 import { JUDGE_MODEL, calculateMetrics, evaluateLLMJudge } from "./metrics";
 import {
 	type BenchRawMessage,
+	type GeneratedAnswer,
 	type MemorySearchHit,
 	generateAnswer,
 	getAnswererModelIdentity,
@@ -426,11 +428,7 @@ export class LoCoMoEvaluator {
 				total_questions: sample.qa_pairs.length,
 				correct_answers: 0,
 				accuracy: 0,
-				token_usage: {
-					prompt_tokens: 0,
-					completion_tokens: 0,
-					total_tokens: 0,
-				},
+				token_usage: unavailableTokenUsage(),
 				predictions: [],
 				error: "No records in storage",
 			};
@@ -480,13 +478,19 @@ export class LoCoMoEvaluator {
 				continue;
 			}
 			const attempt = (existing?.attempt ?? 0) + 1;
+			let answerUsage = unavailableTokenUsage();
+			let judgeUsage = unavailableTokenUsage();
 
 			try {
 				// Retrieve relevant memories, then answer using only those excerpts
-				const response = await this.answerQuestion(qa, sample);
+				const answerResult = await this.answerQuestion(qa, sample);
+				const response = answerResult.text;
+				answerUsage = answerResult.token_usage;
 
 				// Evaluate answer correctness using LLM judge
-				const isCorrect = (await evaluateLLMJudge(qa.question, qa.answer, response)) === 1;
+				const judgeResult = await evaluateLLMJudge(qa.question, qa.answer, response);
+				judgeUsage = judgeResult.token_usage;
+				const isCorrect = judgeResult.score === 1;
 				console.log(
 					`[Q${i + 1}] ${isCorrect ? "✓" : "✗"} Q: "${qa.question.substring(0, 60)}..." GT: "${qa.answer}"`,
 				);
@@ -506,6 +510,7 @@ export class LoCoMoEvaluator {
 					attempt,
 					answerer_model: answererModel,
 					judge_model: judgeModel,
+					token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 					question: qa.question,
 					answer: qa.answer,
 					response,
@@ -541,6 +546,7 @@ export class LoCoMoEvaluator {
 					answerer_model: answererModel,
 					judge_model: judgeModel,
 					error: errorMessage,
+					token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 					question: qa.question,
 					answer: qa.answer,
 					response: `Error: ${errorMessage}`,
@@ -574,11 +580,7 @@ export class LoCoMoEvaluator {
 			total_questions: total,
 			correct_answers: correct,
 			accuracy: total > 0 ? correct / total : 0,
-			token_usage: {
-				prompt_tokens: 0,
-				completion_tokens: 0,
-				total_tokens: 0,
-			},
+			token_usage: sumTokenUsage(predictions.map((prediction) => prediction.token_usage)),
 			predictions,
 		};
 	}
@@ -586,11 +588,11 @@ export class LoCoMoEvaluator {
 	/**
 	 * Answer a question using retrieved memory excerpts.
 	 */
-	private async answerQuestion(qa: QAPair, sample: LoCoMoSample): Promise<string> {
+	private async answerQuestion(qa: QAPair, sample: LoCoMoSample): Promise<GeneratedAnswer> {
 		const hits = await searchMemory(qa.question, RETRIEVAL_LIMIT, this.baseUrl, `locomo_${sample.sample_id}`);
 		const prompt = buildAnswerPrompt(qa, sample, hits);
 		const response = await generateAnswer(prompt);
-		if (!response.trim() || response === "(empty response)") {
+		if (!response.text.trim()) {
 			throw new Error("Answerer returned an empty response");
 		}
 		return response;

--- a/benchmark/locomo/src/index.ts
+++ b/benchmark/locomo/src/index.ts
@@ -5,11 +5,23 @@
  */
 
 import "dotenv/config";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import {
+	getManifestPath,
+	runPreflight,
+	sumTokenUsage,
+	unavailableTokenUsage,
+	writeRunManifest,
+} from "../../run-support";
 import { loadLoCoMoDatasetFromJson } from "./dataset";
-import { LoCoMoEvaluator } from "./evaluator";
-import { calculateCategoryMetrics } from "./metrics";
-import { checkOpencontextHealth, getOpencontextBaseUrl } from "./opencontext-client";
+import { LoCoMoEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
+import { JUDGE_MODEL, calculateCategoryMetrics } from "./metrics";
+import {
+	checkOpencontextHealth,
+	getAnswererModelIdentity,
+	getOpencontextBaseUrl,
+} from "./opencontext-client";
 import { CATEGORY_NAMES } from "./scorer";
 import { RetrievalMode } from "./types";
 import type { EvaluationResult, Prediction } from "./types";
@@ -64,12 +76,6 @@ function parseCliArgs(): CliArgs {
 	}
 
 	const mode = values.mode as RetrievalMode;
-	if (!Object.values(RetrievalMode).includes(mode)) {
-		console.error(
-			`Error: Invalid mode '${mode}'. Must be one of: ${Object.values(RetrievalMode).join(", ")}`,
-		);
-		process.exit(1);
-	}
 
 	let samples: string[] | undefined;
 	if (values.samples) {
@@ -176,25 +182,45 @@ async function printEvaluationSummary(resultsByCategory: Record<string, Predicti
 }
 
 async function main() {
+	const startedAt = new Date().toISOString();
 	const args = parseCliArgs();
-
-	// Resolve the OpenContext memory daemon and verify it is up
 	const baseUrl = args.port ? `http://127.0.0.1:${args.port}` : getOpencontextBaseUrl();
-	try {
-		await checkOpencontextHealth(baseUrl);
-		console.log(`🔌 OpenContext memory daemon: ${baseUrl}`);
-	} catch (error) {
-		console.error(`${error}`);
-		process.exit(1);
+	const benchmarkDir = join(import.meta.dirname, "..");
+	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
+	let filteredSamples: Awaited<ReturnType<typeof loadLoCoMoDatasetFromJson>> = [];
+	const parameterErrors: string[] = [];
+	if (!Object.values(RetrievalMode).includes(args.mode)) {
+		parameterErrors.push(
+			`--mode must be one of: ${Object.values(RetrievalMode).join(", ")} (received: ${args.mode})`,
+		);
+	}
+	if (args.port !== undefined && (!Number.isInteger(args.port) || args.port < 1 || args.port > 65_535)) {
+		parameterErrors.push("--port must be an integer between 1 and 65535");
 	}
 
-	console.log(`\n📁 Loading dataset from: ${args.dataset}`);
-	const samples = await loadLoCoMoDatasetFromJson(args.dataset);
-
-	// Filter samples if sample_ids provided
-	let filteredSamples = samples;
+	await runPreflight({
+		datasetPath: args.dataset,
+		writablePaths: [
+			manifestPath,
+			join(benchmarkDir, "checkpoints", "locomo", ".preflight"),
+			...(args.output ? [args.output] : []),
+		],
+		parameterErrors,
+		validateDataset: async () => {
+			const samples = await loadLoCoMoDatasetFromJson(args.dataset);
+			filteredSamples =
+				args.samples && args.samples.length > 0
+					? samples.filter((sample) => args.samples?.includes(sample.sample_id))
+					: samples;
+			if (filteredSamples.length === 0) {
+				throw new Error("no samples remain after applying --samples");
+			}
+		},
+		checkDaemon: () => checkOpencontextHealth(baseUrl),
+	});
+	console.log(`🔌 OpenContext memory daemon: ${baseUrl}`);
+	console.log(`\n📁 Loaded dataset from: ${args.dataset}`);
 	if (args.samples && args.samples.length > 0) {
-		filteredSamples = samples.filter((s) => args.samples?.includes(s.sample_id));
 		console.log(`🔍 Filtered to ${filteredSamples.length} samples by ID`);
 	}
 
@@ -243,11 +269,7 @@ async function main() {
 				total_questions: sample.qa_pairs.length,
 				correct_answers: 0,
 				accuracy: 0,
-				token_usage: {
-					prompt_tokens: 0,
-					completion_tokens: 0,
-					total_tokens: 0,
-				},
+				token_usage: unavailableTokenUsage(),
 				predictions: [],
 				error: errorMessage,
 			});
@@ -259,19 +281,34 @@ async function main() {
 	const totalCorrect = resultsBySample.reduce((sum, r) => sum + (r.correct_answers || 0), 0);
 	const overallAccuracy = totalQuestions > 0 ? totalCorrect / totalQuestions : 0;
 
-	const totalTokens = resultsBySample.reduce((sum, r) => sum + (r.token_usage?.total_tokens || 0), 0);
+	const runTokenUsage = sumTokenUsage(resultsBySample.map((result) => result.token_usage));
 
 	// Print summary
 	await printEvaluationSummary(allPredictionsByCategory);
 
 	// Prepare output
+	const finishedAt = new Date().toISOString();
+	const runManifest = await writeRunManifest(manifestPath, {
+		benchmark: "locomo",
+		datasetPath: args.dataset,
+		answerer_model: getAnswererModelIdentity(),
+		judge_model: JUDGE_MODEL,
+		retrieval: { strategy: args.mode, top_k: RETRIEVAL_LIMIT },
+		resume: args.resume,
+		started_at: startedAt,
+		finished_at: finishedAt,
+		token_usage: runTokenUsage,
+		parameters: { samples: args.samples ?? null, quick: args.quick ?? false },
+	});
 	const output = {
 		retrieval_mode: args.mode,
 		num_samples: resultsBySample.length,
 		total_questions: totalQuestions,
 		total_correct: totalCorrect,
 		overall_accuracy: overallAccuracy,
-		total_tokens: totalTokens,
+		token_usage: runTokenUsage,
+		total_tokens: runTokenUsage.total_tokens,
+		run_manifest: runManifest,
 		results_by_sample: resultsBySample.map((r) => ({
 			sample_id: r.sample_id,
 			accuracy: r.accuracy,
@@ -285,11 +322,16 @@ async function main() {
 
 	// Save output if requested
 	if (args.output) {
+		await mkdir(dirname(resolve(args.output)), { recursive: true });
 		await writeFile(args.output, JSON.stringify(output, null, 2), "utf-8");
 		console.log(`\n💾 Results saved to: ${args.output}`);
 	}
+	console.log(`🧾 Run manifest saved to: ${manifestPath}`);
 
 	return output;
 }
 
-main().catch(console.error);
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/benchmark/locomo/src/metrics.ts
+++ b/benchmark/locomo/src/metrics.ts
@@ -7,6 +7,8 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
+import { tokenUsage, type TokenUsage } from "../../run-support";
+
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
 	apiKey: process.env.OPENROUTER_API_KEY,
@@ -143,6 +145,11 @@ interface LLMJudgeResult {
 
 export const JUDGE_MODEL = "qwen/qwen3.7-max";
 
+export interface LLMJudgeEvaluation {
+	score: number;
+	token_usage: TokenUsage;
+}
+
 export function parseLLMJudgeResponse(text: string): number {
 	const normalized = text.trim();
 	if (!normalized) {
@@ -179,7 +186,7 @@ export async function evaluateLLMJudge(
 	goldAnswer: string,
 	generatedAnswer: string,
 	maxRetries = 3,
-): Promise<number> {
+): Promise<LLMJudgeEvaluation> {
 	const prompt = LLM_JUDGE_PROMPT.replace("{question}", question)
 		.replace("{gold_answer}", goldAnswer)
 		.replace("{generated_answer}", generatedAnswer);
@@ -188,13 +195,16 @@ export async function evaluateLLMJudge(
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
-			const { text } = await generateText({
+			const { text, usage } = await generateText({
 				model: openrouter(JUDGE_MODEL),
 				system: "You are an impartial judge evaluating answers to questions. Always respond with valid JSON.",
 				prompt,
 			});
 
-			return parseLLMJudgeResponse(text);
+			return {
+				score: parseLLMJudgeResponse(text),
+				token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+			};
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 			console.log(`[Judge] Attempt ${attempt}/${maxRetries} failed: ${lastError.message.substring(0, 80)}`);

--- a/benchmark/locomo/src/metrics.ts
+++ b/benchmark/locomo/src/metrics.ts
@@ -141,11 +141,38 @@ interface LLMJudgeResult {
 	reasoning?: string;
 }
 
+export const JUDGE_MODEL = "qwen/qwen3.7-max";
+
+export function parseLLMJudgeResponse(text: string): number {
+	const normalized = text.trim();
+	if (!normalized) {
+		throw new Error("Judge returned an empty response");
+	}
+
+	try {
+		const result = JSON.parse(normalized) as LLMJudgeResult;
+		const label = result.label?.trim().toUpperCase();
+		if (label === "CORRECT") return 1;
+		if (label === "WRONG") return 0;
+		throw new Error("Judge JSON response is missing a valid CORRECT/WRONG label");
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			const upper = normalized.toUpperCase();
+			const hasCorrect = upper.includes("CORRECT");
+			const hasWrong = upper.includes("WRONG");
+			if (hasCorrect && !hasWrong) return 1;
+			if (hasWrong && !hasCorrect) return 0;
+			throw new Error("Judge response could not be parsed as CORRECT or WRONG", { cause: error });
+		}
+		throw error;
+	}
+}
+
 /**
  * Evaluate the generated answer against the gold answer using an LLM judge.
  * Includes retry logic for handling unstable API connections.
  *
- * Returns 1 for CORRECT, 0 for WRONG.
+ * Returns 1 for CORRECT and 0 for WRONG; throws if no attempt yields a valid label.
  */
 export async function evaluateLLMJudge(
 	question: string,
@@ -162,27 +189,12 @@ export async function evaluateLLMJudge(
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			const { text } = await generateText({
-				model: openrouter("qwen/qwen3.7-max"),
+				model: openrouter(JUDGE_MODEL),
 				system: "You are an impartial judge evaluating answers to questions. Always respond with valid JSON.",
 				prompt,
 			});
 
-			// Parse JSON response
-			let result: LLMJudgeResult;
-			try {
-				result = JSON.parse(text);
-			} catch {
-				// Try to extract label from non-JSON response
-				if (text.toUpperCase().includes("CORRECT") && !text.toUpperCase().includes("WRONG")) {
-					return 1;
-				}
-				return 0;
-			}
-
-			const label = result.label ?? "WRONG";
-			const score = label === "CORRECT" ? 1 : 0;
-
-			return score;
+			return parseLLMJudgeResponse(text);
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 			console.log(`[Judge] Attempt ${attempt}/${maxRetries} failed: ${lastError.message.substring(0, 80)}`);
@@ -193,8 +205,7 @@ export async function evaluateLLMJudge(
 		}
 	}
 
-	console.error(`[Judge] All ${maxRetries} attempts failed. Last error: ${lastError?.message}`);
-	return 0;
+	throw lastError ?? new Error("Judge failed without returning a result");
 }
 
 /**

--- a/benchmark/locomo/src/opencontext-client.ts
+++ b/benchmark/locomo/src/opencontext-client.ts
@@ -12,6 +12,8 @@
  * (OPENROUTER_API_KEY, OPENROUTER_ANSWER_MODEL).
  */
 
+import { tokenUsage, type TokenUsage } from "../../run-support";
+
 export const DEFAULT_OPENCONTEXT_PORT = 7421;
 
 export function getOpencontextBaseUrl(): string {
@@ -27,6 +29,11 @@ export function getAnswererModelIdentity(): string {
 		return `anthropic-compatible:${process.env.ANSWER_MODEL ?? "MiniMax-M3-highspeed"}`;
 	}
 	return `openrouter:${process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"}`;
+}
+
+export interface GeneratedAnswer {
+	text: string;
+	token_usage: TokenUsage;
 }
 
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
@@ -143,7 +150,7 @@ export async function searchMemory(
  * Fallback: OpenRouter chat completions:
  *   OPENROUTER_API_KEY / OPENROUTER_ANSWER_MODEL (default deepseek/deepseek-chat)
  */
-export async function generateAnswer(prompt: string, system?: string): Promise<string> {
+export async function generateAnswer(prompt: string, system?: string): Promise<GeneratedAnswer> {
 	const token = process.env.ANTHROPIC_AUTH_TOKEN;
 	if (token) {
 		const base = (process.env.ANTHROPIC_BASE_URL ?? "https://api.minimaxi.com/anthropic").replace(/\/+$/, "");
@@ -168,12 +175,16 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		}
 		const data = (await res.json()) as {
 			content?: Array<{ type: string; text?: string }>;
+			usage?: { input_tokens?: number; output_tokens?: number };
 		};
 		const text = (data.content ?? [])
 			.filter((b) => b.type === "text" && typeof b.text === "string")
 			.map((b) => b.text as string)
 			.join("");
-		return text || "(empty response)";
+		return {
+			text,
+			token_usage: tokenUsage(data.usage?.input_tokens, data.usage?.output_tokens, undefined),
+		};
 	}
 
 	const openrouterKey = process.env.OPENROUTER_API_KEY;
@@ -187,10 +198,13 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		apiKey: openrouterKey,
 		name: "openrouter",
 	});
-	const { text } = await generateText({
+	const { text, usage } = await generateText({
 		model: openrouter(process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"),
 		...(system ? { system } : {}),
 		prompt,
 	});
-	return text;
+	return {
+		text,
+		token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+	};
 }

--- a/benchmark/locomo/src/opencontext-client.ts
+++ b/benchmark/locomo/src/opencontext-client.ts
@@ -22,6 +22,13 @@ export function getOpencontextBaseUrl(): string {
 
 export const BENCH_USER_ID = "benchmark_user";
 
+export function getAnswererModelIdentity(): string {
+	if (process.env.ANTHROPIC_AUTH_TOKEN) {
+		return `anthropic-compatible:${process.env.ANSWER_MODEL ?? "MiniMax-M3-highspeed"}`;
+	}
+	return `openrouter:${process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"}`;
+}
+
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
 	let res: Response;
 	try {

--- a/benchmark/locomo/src/run-support.test.ts
+++ b/benchmark/locomo/src/run-support.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	collectPreflightErrors,
+	sumTokenUsage,
+	tokenUsage,
+	unavailableTokenUsage,
+	writeRunManifest,
+} from "../../run-support";
+
+const temporaryDirectories: string[] = [];
+
+async function makeTemporaryDirectory(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "opencontext-benchmark-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("benchmark run support", () => {
+	it("reports independent preflight failures together before execution", async () => {
+		const directory = await makeTemporaryDirectory();
+		const dataset = join(directory, "fixture.json");
+		await writeFile(dataset, "{}", "utf-8");
+		vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
+		vi.stubEnv("OPENROUTER_API_KEY", "");
+
+		const errors = await collectPreflightErrors({
+			datasetPath: dataset,
+			writablePaths: [join(directory, "nested", "result.json")],
+			parameterErrors: ["--port must be valid"],
+			validateDataset: async () => {
+				throw new Error("fixture schema is invalid");
+			},
+			checkDaemon: async () => {
+				throw new Error("daemon is unavailable");
+			},
+		});
+
+		expect(errors).toEqual([
+			"--port must be valid",
+			"dataset validation failed: fixture schema is invalid",
+			"daemon is unavailable",
+			"answerer credential missing: set ANTHROPIC_AUTH_TOKEN or OPENROUTER_API_KEY",
+			"judge credential missing: set OPENROUTER_API_KEY",
+		]);
+	});
+
+	it("keeps unavailable provider usage as null instead of fabricating zero", () => {
+		expect(sumTokenUsage([tokenUsage(3, 2, 5), unavailableTokenUsage()])).toEqual({
+			prompt_tokens: null,
+			completion_tokens: null,
+			total_tokens: null,
+		});
+	});
+
+	it("writes the minimum reproducibility manifest with a real dataset identity", async () => {
+		const directory = await makeTemporaryDirectory();
+		const dataset = join(directory, "fixture.json");
+		const output = join(directory, "result.manifest.json");
+		await writeFile(dataset, '{"fixture":true}', "utf-8");
+
+		const manifest = await writeRunManifest(output, {
+			benchmark: "fixture",
+			datasetPath: dataset,
+			answerer_model: "fixture-answerer",
+			judge_model: "fixture-judge",
+			retrieval: { strategy: "memory-search", top_k: 8 },
+			resume: false,
+			started_at: "2026-01-01T00:00:00.000Z",
+			finished_at: "2026-01-01T00:00:01.250Z",
+			token_usage: unavailableTokenUsage(),
+			parameters: { quick: true },
+		});
+
+		expect(manifest.schema_version).toBe(1);
+		expect(manifest.dataset.path).toBe(dataset);
+		expect(manifest.dataset.sha256).toMatch(/^[a-f0-9]{64}$/);
+		expect(manifest.wall_clock_ms).toBe(1_250);
+		expect(manifest.token_usage.total_tokens).toBeNull();
+		expect(JSON.parse(await readFile(output, "utf-8"))).toEqual(manifest);
+	});
+});

--- a/benchmark/locomo/src/types.ts
+++ b/benchmark/locomo/src/types.ts
@@ -2,6 +2,8 @@
  * Types for LoCoMo benchmark evaluation.
  */
 
+import type { TokenUsage } from "../../run-support";
+
 export enum RetrievalMode {
 	DIALOG = "dialog",
 	OBSERVATION = "observation",
@@ -30,11 +32,7 @@ export interface EvaluationResult {
 	total_questions: number;
 	correct_answers: number;
 	accuracy: number;
-	token_usage: {
-		prompt_tokens: number;
-		completion_tokens: number;
-		total_tokens: number;
-	};
+	token_usage: TokenUsage;
 	predictions: Prediction[];
 	error?: string;
 }
@@ -45,6 +43,7 @@ export interface Prediction {
 	answerer_model: string;
 	judge_model: string;
 	error?: string;
+	token_usage: TokenUsage;
 	question: string;
 	answer: string;
 	response: string;

--- a/benchmark/locomo/src/types.ts
+++ b/benchmark/locomo/src/types.ts
@@ -40,6 +40,11 @@ export interface EvaluationResult {
 }
 
 export interface Prediction {
+	status: "completed" | "execution_error";
+	attempt: number;
+	answerer_model: string;
+	judge_model: string;
+	error?: string;
 	question: string;
 	answer: string;
 	response: string;

--- a/benchmark/locomo/tsconfig.json
+++ b/benchmark/locomo/tsconfig.json
@@ -7,7 +7,7 @@
 		"strict": true,
 		"skipLibCheck": true,
 		"outDir": "./dist",
-		"rootDir": "./src",
+		"rootDir": "..",
 		"resolveJsonModule": true,
 		"declaration": true
 	},

--- a/benchmark/longmemeval/README.md
+++ b/benchmark/longmemeval/README.md
@@ -95,8 +95,16 @@ pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json --output results.
 | `--quick`     | `-q`  | Limit to first 5 entries            | false              |
 | `--output`    | `-o`  | Save results JSON to path           | None               |
 | `--port`      | `-p`  | OpenContext daemon port (env: `OPENCONTEXT_PORT` / `OPENCONTEXT_URL`) | 7421 |
-| `--resume`    |       | Resume from checkpoints             | true               |
-| `--no-resume` |       | Start fresh (don't resume)          | false              |
+| `--resume`    |       | Reuse completed checkpoints for the same models | true    |
+| `--no-resume` |       | Ignore checkpoints and run every selected entry | false   |
+
+Before ingest or model calls, the CLI checks the dataset and selected entries,
+daemon, credentials, output/checkpoint paths, and arguments. It reports all
+detected failures together and never prints credential values. `--help` does not
+run these checks.
+
+With `--resume`, both correct and incorrect completed judge results are reused;
+only execution failures are retried. `--no-resume` always starts a fresh run.
 
 ## Output
 
@@ -105,7 +113,12 @@ The benchmark outputs:
 - **Overall accuracy** - LLM judge accuracy across all question types
 - **Per-type metrics** - F1, BLEU-1, BLEU-4 scores by question type
 - **Per-question predictions** - Individual question results
-- **Token totals** - Combined API token consumption
+- **Token usage** - Real provider usage when available; otherwise `null`
+- **Run manifest** - Git commit, dataset identity, models, retrieval top-k,
+  selection parameters, resume mode, and wall-clock time
+
+With `--output results.json`, the manifest is written to
+`results.json.manifest.json`. Without `--output`, it is written under `results/`.
 
 ### Metrics
 

--- a/benchmark/longmemeval/package.json
+++ b/benchmark/longmemeval/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"
 	},

--- a/benchmark/longmemeval/package.json
+++ b/benchmark/longmemeval/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"

--- a/benchmark/longmemeval/src/evaluator.test.ts
+++ b/benchmark/longmemeval/src/evaluator.test.ts
@@ -28,6 +28,11 @@ import type { LongMemEvalEntry } from "./types";
 const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
 const originalAnswerModel = process.env.ANSWER_MODEL;
 const temporaryDirectories: string[] = [];
+const fixtureUsage = { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 };
+
+function judgeResult(score: number) {
+	return { score, token_usage: fixtureUsage };
+}
 
 function restoreEnvironment(name: string, value: string | undefined): void {
 	if (value === undefined) delete process.env[name];
@@ -65,7 +70,7 @@ beforeEach(() => {
 	process.env.ANTHROPIC_AUTH_TOKEN = "fixture-token";
 	process.env.ANSWER_MODEL = "answerer-a";
 	vi.mocked(searchMemory).mockResolvedValue([]);
-	vi.mocked(generateAnswer).mockResolvedValue("fixture response");
+	vi.mocked(generateAnswer).mockResolvedValue({ text: "fixture response", token_usage: fixtureUsage });
 });
 
 afterEach(async () => {
@@ -81,12 +86,13 @@ describe("LongMemEval checkpoint resume", () => {
 		const checkpointDir = await createCheckpointDir();
 		const correctEntry = createEntry("correct-entry");
 		const incorrectEntry = createEntry("incorrect-entry");
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1)).mockResolvedValueOnce(judgeResult(0));
 
 		const firstEvaluator = createEvaluator(checkpointDir);
 		const correct = await firstEvaluator.evaluateQuestion(correctEntry);
 		const incorrect = await firstEvaluator.evaluateQuestion(incorrectEntry);
 		expect([correct.status, incorrect.status]).toEqual(["completed", "completed"]);
+		expect(correct.token_usage).toEqual({ prompt_tokens: 20, completion_tokens: 10, total_tokens: 30 });
 
 		vi.mocked(generateAnswer).mockClear();
 		vi.mocked(evaluateLLMJudge).mockClear();
@@ -115,7 +121,7 @@ describe("LongMemEval checkpoint resume", () => {
 		});
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		const retried = await createEvaluator(checkpointDir).evaluateQuestion(entry);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -125,11 +131,11 @@ describe("LongMemEval checkpoint resume", () => {
 	it("ignores existing checkpoints when resume is disabled", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const entry = createEntry("fresh-entry");
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		await createEvaluator(checkpointDir).evaluateQuestion(entry);
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1));
 		const fresh = await createEvaluator(checkpointDir, false).evaluateQuestion(entry);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -139,12 +145,12 @@ describe("LongMemEval checkpoint resume", () => {
 	it("does not reuse a checkpoint from a different answerer or judge model", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const entry = createEntry("model-entry");
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		await createEvaluator(checkpointDir).evaluateQuestion(entry);
 
 		process.env.ANSWER_MODEL = "answerer-b";
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1));
 		const rerun = await createEvaluator(checkpointDir).evaluateQuestion(entry);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -160,7 +166,7 @@ describe("LongMemEval checkpoint resume", () => {
 		await writeFile(checkpointPath, JSON.stringify(checkpoint), "utf-8");
 
 		vi.mocked(generateAnswer).mockClear();
-		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(0));
 		const judgeRerun = await createEvaluator(checkpointDir).evaluateQuestion(entry);
 
 		expect(generateAnswer).toHaveBeenCalledOnce();
@@ -173,7 +179,7 @@ describe("LongMemEval checkpoint resume", () => {
 
 	it("records an empty answer as an execution error without calling the judge", async () => {
 		const checkpointDir = await createCheckpointDir();
-		vi.mocked(generateAnswer).mockResolvedValueOnce("");
+		vi.mocked(generateAnswer).mockResolvedValueOnce({ text: "", token_usage: fixtureUsage });
 
 		const result = await createEvaluator(checkpointDir).evaluateQuestion(createEntry("empty-entry"));
 

--- a/benchmark/longmemeval/src/evaluator.test.ts
+++ b/benchmark/longmemeval/src/evaluator.test.ts
@@ -1,0 +1,194 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./opencontext-client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./opencontext-client")>();
+	return {
+		...actual,
+		generateAnswer: vi.fn(),
+		searchMemory: vi.fn(),
+	};
+});
+
+vi.mock("./metrics", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./metrics")>();
+	return {
+		...actual,
+		evaluateLLMJudge: vi.fn(),
+	};
+});
+
+import { LongMemEvalEvaluator } from "./evaluator";
+import { JUDGE_MODEL, evaluateLLMJudge, parseLLMJudgeResponse } from "./metrics";
+import { generateAnswer, searchMemory } from "./opencontext-client";
+import type { LongMemEvalEntry } from "./types";
+
+const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+const originalAnswerModel = process.env.ANSWER_MODEL;
+const temporaryDirectories: string[] = [];
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}
+
+async function createCheckpointDir(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "opencontext-longmemeval-checkpoint-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function createEvaluator(checkpointDir: string, resume = true): LongMemEvalEvaluator {
+	const evaluator = new LongMemEvalEvaluator("http://fixture.invalid", undefined, resume);
+	Object.assign(evaluator, { checkpointDir });
+	return evaluator;
+}
+
+function createEntry(questionId: string): LongMemEvalEntry {
+	return {
+		question_id: questionId,
+		question_type: "single-session-user",
+		question: `Question for ${questionId}?`,
+		question_date: "2024-01-01",
+		answer: `Answer for ${questionId}`,
+		answer_session_ids: [],
+		haystack_dates: [],
+		haystack_session_ids: [],
+		haystack_sessions: [],
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env.ANTHROPIC_AUTH_TOKEN = "fixture-token";
+	process.env.ANSWER_MODEL = "answerer-a";
+	vi.mocked(searchMemory).mockResolvedValue([]);
+	vi.mocked(generateAnswer).mockResolvedValue("fixture response");
+});
+
+afterEach(async () => {
+	restoreEnvironment("ANTHROPIC_AUTH_TOKEN", originalAuthToken);
+	restoreEnvironment("ANSWER_MODEL", originalAnswerModel);
+	await Promise.all(
+		temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+describe("LongMemEval checkpoint resume", () => {
+	it("reuses both correct and incorrect completed results across repeated resumes", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const correctEntry = createEntry("correct-entry");
+		const incorrectEntry = createEntry("incorrect-entry");
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+
+		const firstEvaluator = createEvaluator(checkpointDir);
+		const correct = await firstEvaluator.evaluateQuestion(correctEntry);
+		const incorrect = await firstEvaluator.evaluateQuestion(incorrectEntry);
+		expect([correct.status, incorrect.status]).toEqual(["completed", "completed"]);
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockClear();
+		const secondEvaluator = createEvaluator(checkpointDir);
+		const resumedCorrect = await secondEvaluator.evaluateQuestion(correctEntry);
+		const resumedIncorrect = await secondEvaluator.evaluateQuestion(incorrectEntry);
+		const resumedAgain = await createEvaluator(checkpointDir).evaluateQuestion(incorrectEntry);
+
+		expect(generateAnswer).not.toHaveBeenCalled();
+		expect(evaluateLLMJudge).not.toHaveBeenCalled();
+		expect(resumedCorrect.correct).toBe(true);
+		expect(resumedIncorrect.correct).toBe(false);
+		expect(resumedAgain.correct).toBe(false);
+	});
+
+	it("retries execution errors and increments the attempt", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const entry = createEntry("retry-entry");
+		vi.mocked(evaluateLLMJudge).mockRejectedValueOnce(new Error("judge parse failure"));
+
+		const failed = await createEvaluator(checkpointDir).evaluateQuestion(entry);
+		expect(failed).toMatchObject({
+			status: "execution_error",
+			attempt: 1,
+			error: "judge parse failure",
+		});
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		const retried = await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(retried).toMatchObject({ status: "completed", attempt: 2, correct: false });
+	});
+
+	it("ignores existing checkpoints when resume is disabled", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const entry = createEntry("fresh-entry");
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		const fresh = await createEvaluator(checkpointDir, false).evaluateQuestion(entry);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(fresh).toMatchObject({ status: "completed", attempt: 1, correct: true });
+	});
+
+	it("does not reuse a checkpoint from a different answerer or judge model", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const entry = createEntry("model-entry");
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		process.env.ANSWER_MODEL = "answerer-b";
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(1);
+		const rerun = await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(rerun).toMatchObject({
+			status: "completed",
+			attempt: 2,
+			answerer_model: "anthropic-compatible:answerer-b",
+		});
+
+		const checkpointPath = join(checkpointDir, `${entry.question_id}.json`);
+		const checkpoint = JSON.parse(await readFile(checkpointPath, "utf-8")) as Record<string, unknown>;
+		checkpoint.judge_model = "different-judge";
+		await writeFile(checkpointPath, JSON.stringify(checkpoint), "utf-8");
+
+		vi.mocked(generateAnswer).mockClear();
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(0);
+		const judgeRerun = await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		expect(generateAnswer).toHaveBeenCalledOnce();
+		expect(judgeRerun).toMatchObject({
+			status: "completed",
+			attempt: 3,
+			judge_model: JUDGE_MODEL,
+		});
+	});
+
+	it("records an empty answer as an execution error without calling the judge", async () => {
+		const checkpointDir = await createCheckpointDir();
+		vi.mocked(generateAnswer).mockResolvedValueOnce("");
+
+		const result = await createEvaluator(checkpointDir).evaluateQuestion(createEntry("empty-entry"));
+
+		expect(evaluateLLMJudge).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			status: "execution_error",
+			error: "Answerer returned an empty response",
+		});
+	});
+});
+
+describe("LongMemEval judge parsing", () => {
+	it("accepts explicit labels and rejects an unparseable response", () => {
+		expect(parseLLMJudgeResponse('{"label":"CORRECT"}')).toBe(1);
+		expect(parseLLMJudgeResponse("WRONG")).toBe(0);
+		expect(() => parseLLMJudgeResponse("unknown")).toThrow("could not be parsed");
+	});
+});

--- a/benchmark/longmemeval/src/evaluator.ts
+++ b/benchmark/longmemeval/src/evaluator.ts
@@ -14,9 +14,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { sumTokenUsage, unavailableTokenUsage } from "../../run-support";
 import { JUDGE_MODEL, calculateMetrics, evaluateLLMJudge } from "./metrics";
 import {
 	type BenchRawMessage,
+	type GeneratedAnswer,
 	type MemorySearchHit,
 	checkOpencontextHealth,
 	generateAnswer,
@@ -263,12 +265,18 @@ export class LongMemEvalEvaluator {
 
 		// Convert answer to string (may be number in dataset)
 		const answerStr = String(entry.answer);
+		let answerUsage = unavailableTokenUsage();
+		let judgeUsage = unavailableTokenUsage();
 
 		try {
-			const response = await this.queryMemory(entry);
+			const answerResult = await this.queryMemory(entry);
+			const response = answerResult.text;
+			answerUsage = answerResult.token_usage;
 
 			// Evaluate answer correctness using LLM judge
-			const isCorrect = (await evaluateLLMJudge(entry.question, answerStr, response)) === 1;
+			const judgeResult = await evaluateLLMJudge(entry.question, answerStr, response);
+			judgeUsage = judgeResult.token_usage;
+			const isCorrect = judgeResult.score === 1;
 
 			// Calculate additional metrics
 			const metrics = calculateMetrics(response, answerStr);
@@ -278,6 +286,7 @@ export class LongMemEvalEvaluator {
 				attempt,
 				answerer_model: answererModel,
 				judge_model: judgeModel,
+				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 				question: entry.question,
 				answer: answerStr,
 				response,
@@ -308,6 +317,7 @@ export class LongMemEvalEvaluator {
 				answerer_model: answererModel,
 				judge_model: judgeModel,
 				error: errorMessage,
+				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
 				question: entry.question,
 				answer: answerStr,
 				response: `Error: ${errorMessage}`,
@@ -333,7 +343,7 @@ export class LongMemEvalEvaluator {
 	/**
 	 * Retrieve relevant memories and answer the question with the answerer LLM.
 	 */
-	private async queryMemory(entry: LongMemEvalEntry): Promise<string> {
+	private async queryMemory(entry: LongMemEvalEntry): Promise<GeneratedAnswer> {
 		const hits = await searchMemory(
 			entry.question,
 			RETRIEVAL_LIMIT,
@@ -342,7 +352,7 @@ export class LongMemEvalEvaluator {
 		);
 		const prompt = buildAnswerPrompt(entry, hits);
 		const response = await generateAnswer(prompt);
-		if (!response.trim() || response === "(empty response)") {
+		if (!response.text.trim()) {
 			throw new Error("Answerer returned an empty response");
 		}
 		return response;

--- a/benchmark/longmemeval/src/evaluator.ts
+++ b/benchmark/longmemeval/src/evaluator.ts
@@ -8,18 +8,19 @@
  *   2. evaluateQuestion: retrieve relevant sessions (`POST /v1/search`),
  *      then ask the answerer LLM (see opencontext-client.ts) using only
  *      the retrieved excerpts.
- *   3. Judge unchanged (metrics.ts, OpenRouter).
+ *   3. Judge with the existing metrics.ts model and prompt (OpenRouter).
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { calculateMetrics, evaluateLLMJudge } from "./metrics";
+import { JUDGE_MODEL, calculateMetrics, evaluateLLMJudge } from "./metrics";
 import {
 	type BenchRawMessage,
 	type MemorySearchHit,
 	checkOpencontextHealth,
 	generateAnswer,
+	getAnswererModelIdentity,
 	getOpencontextBaseUrl,
 	ingestMessages,
 	searchMemory,
@@ -28,6 +29,18 @@ import type { LongMemEvalEntry, Prediction } from "./types";
 
 /** How many retrieved sessions are shown to the answerer. */
 export const RETRIEVAL_LIMIT = 8;
+
+function isReusableCheckpoint(
+	prediction: Prediction | null,
+	answererModel: string,
+	judgeModel: string,
+): boolean {
+	return (
+		prediction?.status === "completed" &&
+		prediction.answerer_model === answererModel &&
+		prediction.judge_model === judgeModel
+	);
+}
 
 /**
  * Parse timestamp string to Unix ms.
@@ -233,11 +246,20 @@ export class LongMemEvalEvaluator {
 	 * Evaluate a single question.
 	 */
 	async evaluateQuestion(entry: LongMemEvalEntry): Promise<Prediction> {
-		// Check for checkpoint (resume support) - skip if error or incorrect
 		const checkpoint = await this.loadCheckpoint(entry.question_id);
-		if (checkpoint?.response && checkpoint.correct && !checkpoint.response.startsWith("Error:")) {
+		const answererModel = getAnswererModelIdentity();
+		const judgeModel = JUDGE_MODEL;
+		if (checkpoint && isReusableCheckpoint(checkpoint, answererModel, judgeModel)) {
 			return checkpoint;
 		}
+		if (checkpoint) {
+			const message =
+				checkpoint.status === "execution_error"
+					? `Retrying ${entry.question_id}: execution error`
+					: `Re-running ${entry.question_id}: legacy/model mismatch`;
+			process.stdout.write(`[LongMemEval] ${message}\n`);
+		}
+		const attempt = (checkpoint?.attempt ?? 0) + 1;
 
 		// Convert answer to string (may be number in dataset)
 		const answerStr = String(entry.answer);
@@ -246,19 +268,16 @@ export class LongMemEvalEvaluator {
 			const response = await this.queryMemory(entry);
 
 			// Evaluate answer correctness using LLM judge
-			let isCorrect = false;
-			try {
-				isCorrect = (await evaluateLLMJudge(entry.question, answerStr, response)) === 1;
-				if (!isCorrect) {
-				}
-			} catch (judgeError) {
-				const _errMsg = judgeError instanceof Error ? judgeError.message : String(judgeError);
-			}
+			const isCorrect = (await evaluateLLMJudge(entry.question, answerStr, response)) === 1;
 
 			// Calculate additional metrics
 			const metrics = calculateMetrics(response, answerStr);
 
 			const pred: Prediction = {
+				status: "completed",
+				attempt,
+				answerer_model: answererModel,
+				judge_model: judgeModel,
 				question: entry.question,
 				answer: answerStr,
 				response,
@@ -284,6 +303,11 @@ export class LongMemEvalEvaluator {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 
 			const pred: Prediction = {
+				status: "execution_error",
+				attempt,
+				answerer_model: answererModel,
+				judge_model: judgeModel,
+				error: errorMessage,
 				question: entry.question,
 				answer: answerStr,
 				response: `Error: ${errorMessage}`,
@@ -317,6 +341,10 @@ export class LongMemEvalEvaluator {
 			`lme_${entry.question_id}`,
 		);
 		const prompt = buildAnswerPrompt(entry, hits);
-		return await generateAnswer(prompt);
+		const response = await generateAnswer(prompt);
+		if (!response.trim() || response === "(empty response)") {
+			throw new Error("Answerer returned an empty response");
+		}
+		return response;
 	}
 }

--- a/benchmark/longmemeval/src/index.ts
+++ b/benchmark/longmemeval/src/index.ts
@@ -71,7 +71,31 @@ function parseCliArgs(): CliArgs {
 	};
 }
 
-function printHelp(): void {}
+function printHelp(): void {
+	// biome-ignore lint/suspicious/noConsole: CLI help is intentionally written to stdout
+	console.log(`LongMemEval Benchmark CLI
+
+Usage:
+  pnpm benchmark -- --dataset <path.json> [options]
+
+Required:
+  -d, --dataset <path>        Path to LongMemEval JSON dataset
+
+Filter:
+  -s, --samples <csv>         Filter to question IDs (csv)
+  -q, --quick                 Run the first 5 entries
+
+Mode:
+      --resume / --no-resume  Reuse cached judge results (default: resume)
+
+API:
+  -p, --port <n>              OpenContext memory daemon port (default: 7421,
+                              env: OPENCONTEXT_PORT / OPENCONTEXT_URL)
+
+Output:
+  -o, --output <path>         Write results JSON to this path
+`);
+}
 
 async function printEvaluationSummary(resultsByType: Record<string, Prediction[]>): Promise<void> {
 	// Calculate overall metrics

--- a/benchmark/longmemeval/src/index.ts
+++ b/benchmark/longmemeval/src/index.ts
@@ -5,9 +5,17 @@
  */
 
 import "dotenv/config";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import {
+	getManifestPath,
+	runPreflight,
+	sumTokenUsage,
+	unavailableTokenUsage,
+	writeRunManifest,
+} from "../../run-support";
 import { loadLongMemEvalDatasetFromJson } from "./dataset";
-import { LongMemEvalEvaluator } from "./evaluator";
+import { LongMemEvalEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
 import { JUDGE_MODEL, calculateCategoryMetrics } from "./metrics";
 import {
 	checkOpencontextHealth,
@@ -117,27 +125,38 @@ async function printEvaluationSummary(resultsByType: Record<string, Prediction[]
 }
 
 async function main() {
+	const startedAt = new Date().toISOString();
 	const args = parseCliArgs();
-
-	// Resolve the OpenContext memory daemon and verify it is up
 	const baseUrl = args.port ? `http://127.0.0.1:${args.port}` : getOpencontextBaseUrl();
-	try {
-		await checkOpencontextHealth(baseUrl);
-	} catch (_error) {
-		process.exit(1);
-	}
-	const entries = await loadLongMemEvalDatasetFromJson(args.dataset);
-
-	// Filter entries if sample_ids provided
-	let filteredEntries = entries;
-	if (args.samples && args.samples.length > 0) {
-		filteredEntries = entries.filter((e) => args.samples?.includes(e.question_id));
+	const benchmarkDir = join(import.meta.dirname, "..");
+	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
+	let filteredEntries: Awaited<ReturnType<typeof loadLongMemEvalDatasetFromJson>> = [];
+	const parameterErrors: string[] = [];
+	if (args.port !== undefined && (!Number.isInteger(args.port) || args.port < 1 || args.port > 65_535)) {
+		parameterErrors.push("--port must be an integer between 1 and 65535");
 	}
 
-	// Apply quick mode (first 5 entries only)
-	if (args.quick) {
-		filteredEntries = filteredEntries.slice(0, 5);
-	}
+	await runPreflight({
+		datasetPath: args.dataset,
+		writablePaths: [
+			manifestPath,
+			join(benchmarkDir, "checkpoints", "longmemeval", ".preflight"),
+			...(args.output ? [args.output] : []),
+		],
+		parameterErrors,
+		validateDataset: async () => {
+			const entries = await loadLongMemEvalDatasetFromJson(args.dataset);
+			filteredEntries =
+				args.samples && args.samples.length > 0
+					? entries.filter((entry) => args.samples?.includes(entry.question_id))
+					: entries;
+			if (args.quick) filteredEntries = filteredEntries.slice(0, 5);
+			if (filteredEntries.length === 0) {
+				throw new Error("no entries remain after applying --samples/--quick");
+			}
+		},
+		checkDaemon: () => checkOpencontextHealth(baseUrl),
+	});
 
 	// Run evaluation
 	const allPredictionsByType: Record<string, Prediction[]> = {};
@@ -170,6 +189,7 @@ async function main() {
 
 			// Record failed prediction
 			const failedPred: Prediction = {
+				token_usage: unavailableTokenUsage(),
 				status: "execution_error",
 				attempt: 1,
 				answerer_model: getAnswererModelIdentity(),
@@ -206,12 +226,29 @@ async function main() {
 
 	// Prepare output
 	const overallAccuracy = total > 0 ? correct / total : 0;
+	const predictions = Object.values(allPredictionsByType).flat();
+	const runTokenUsage = sumTokenUsage(predictions.map((prediction) => prediction.token_usage));
+	const finishedAt = new Date().toISOString();
+	const runManifest = await writeRunManifest(manifestPath, {
+		benchmark: "longmemeval",
+		datasetPath: args.dataset,
+		answerer_model: getAnswererModelIdentity(),
+		judge_model: JUDGE_MODEL,
+		retrieval: { strategy: "memory-search", top_k: RETRIEVAL_LIMIT },
+		resume: args.resume,
+		started_at: startedAt,
+		finished_at: finishedAt,
+		token_usage: runTokenUsage,
+		parameters: { samples: args.samples ?? null, quick: args.quick ?? false },
+	});
 
 	const output = {
 		num_entries: filteredEntries.length,
 		total_questions: total,
 		total_correct: correct,
 		overall_accuracy: overallAccuracy,
+		token_usage: runTokenUsage,
+		run_manifest: runManifest,
 		results_by_type: Object.fromEntries(
 			Object.entries(allPredictionsByType).map(([qtype, preds]) => {
 				const metrics = calculateCategoryMetrics(preds);
@@ -233,15 +270,22 @@ async function main() {
 				];
 			}),
 		),
-		predictions: Object.values(allPredictionsByType).flat(),
+		predictions,
 	};
 
 	// Save output if requested
 	if (args.output) {
+		await mkdir(dirname(resolve(args.output)), { recursive: true });
 		await writeFile(args.output, JSON.stringify(output, null, 2), "utf-8");
 	}
+	// biome-ignore lint/suspicious/noConsole: benchmark CLI reports the manifest artifact path
+	console.log(`Run manifest saved to: ${manifestPath}`);
 
 	return output;
 }
 
-main().catch(console.error);
+main().catch((error) => {
+	// biome-ignore lint/suspicious/noConsole: fatal CLI errors must be visible to the caller
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/benchmark/longmemeval/src/index.ts
+++ b/benchmark/longmemeval/src/index.ts
@@ -8,8 +8,12 @@ import "dotenv/config";
 import { writeFile } from "node:fs/promises";
 import { loadLongMemEvalDatasetFromJson } from "./dataset";
 import { LongMemEvalEvaluator } from "./evaluator";
-import { calculateCategoryMetrics } from "./metrics";
-import { checkOpencontextHealth, getOpencontextBaseUrl } from "./opencontext-client";
+import { JUDGE_MODEL, calculateCategoryMetrics } from "./metrics";
+import {
+	checkOpencontextHealth,
+	getAnswererModelIdentity,
+	getOpencontextBaseUrl,
+} from "./opencontext-client";
 import { QUESTION_TYPE_NAMES } from "./scorer";
 import type { Prediction } from "./types";
 
@@ -166,6 +170,11 @@ async function main() {
 
 			// Record failed prediction
 			const failedPred: Prediction = {
+				status: "execution_error",
+				attempt: 1,
+				answerer_model: getAnswererModelIdentity(),
+				judge_model: JUDGE_MODEL,
+				error: errorMessage,
 				question: entry.question,
 				answer: entry.answer,
 				response: `Error: ${errorMessage}`,

--- a/benchmark/longmemeval/src/metrics.ts
+++ b/benchmark/longmemeval/src/metrics.ts
@@ -7,6 +7,8 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
+import { tokenUsage, type TokenUsage } from "../../run-support";
+
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
 	apiKey: process.env.OPENROUTER_API_KEY,
@@ -143,6 +145,11 @@ interface LLMJudgeResult {
 
 export const JUDGE_MODEL = "qwen/qwen3.7-max";
 
+export interface LLMJudgeEvaluation {
+	score: number;
+	token_usage: TokenUsage;
+}
+
 export function parseLLMJudgeResponse(text: string): number {
 	const normalized = text.trim();
 	if (!normalized) {
@@ -179,7 +186,7 @@ export async function evaluateLLMJudge(
 	goldAnswer: string,
 	generatedAnswer: string,
 	maxRetries = 3,
-): Promise<number> {
+): Promise<LLMJudgeEvaluation> {
 	const prompt = LLM_JUDGE_PROMPT.replace("{question}", question)
 		.replace("{gold_answer}", goldAnswer)
 		.replace("{generated_answer}", generatedAnswer);
@@ -188,13 +195,16 @@ export async function evaluateLLMJudge(
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
-			const { text } = await generateText({
+			const { text, usage } = await generateText({
 				model: openrouter(JUDGE_MODEL),
 				system: "You are an impartial judge evaluating answers to questions. Always respond with valid JSON.",
 				prompt,
 			});
 
-			return parseLLMJudgeResponse(text);
+			return {
+				score: parseLLMJudgeResponse(text),
+				token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+			};
 		} catch (error) {
 			_lastError = error instanceof Error ? error : new Error(String(error));
 			if (attempt < maxRetries) {

--- a/benchmark/longmemeval/src/metrics.ts
+++ b/benchmark/longmemeval/src/metrics.ts
@@ -141,11 +141,38 @@ interface LLMJudgeResult {
 	reasoning?: string;
 }
 
+export const JUDGE_MODEL = "qwen/qwen3.7-max";
+
+export function parseLLMJudgeResponse(text: string): number {
+	const normalized = text.trim();
+	if (!normalized) {
+		throw new Error("Judge returned an empty response");
+	}
+
+	try {
+		const result = JSON.parse(normalized) as LLMJudgeResult;
+		const label = result.label?.trim().toUpperCase();
+		if (label === "CORRECT") return 1;
+		if (label === "WRONG") return 0;
+		throw new Error("Judge JSON response is missing a valid CORRECT/WRONG label");
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			const upper = normalized.toUpperCase();
+			const hasCorrect = upper.includes("CORRECT");
+			const hasWrong = upper.includes("WRONG");
+			if (hasCorrect && !hasWrong) return 1;
+			if (hasWrong && !hasCorrect) return 0;
+			throw new Error("Judge response could not be parsed as CORRECT or WRONG", { cause: error });
+		}
+		throw error;
+	}
+}
+
 /**
  * Evaluate the generated answer against the gold answer using an LLM judge.
  * Includes retry logic for handling unstable API connections.
  *
- * Returns 1 for CORRECT, 0 for WRONG.
+ * Returns 1 for CORRECT and 0 for WRONG; throws if no attempt yields a valid label.
  */
 export async function evaluateLLMJudge(
 	question: string,
@@ -162,27 +189,12 @@ export async function evaluateLLMJudge(
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			const { text } = await generateText({
-				model: openrouter("qwen/qwen3.7-max"),
+				model: openrouter(JUDGE_MODEL),
 				system: "You are an impartial judge evaluating answers to questions. Always respond with valid JSON.",
 				prompt,
 			});
 
-			// Parse JSON response
-			let result: LLMJudgeResult;
-			try {
-				result = JSON.parse(text);
-			} catch {
-				// Try to extract label from non-JSON response
-				if (text.toUpperCase().includes("CORRECT") && !text.toUpperCase().includes("WRONG")) {
-					return 1;
-				}
-				return 0;
-			}
-
-			const label = result.label ?? "WRONG";
-			const score = label === "CORRECT" ? 1 : 0;
-
-			return score;
+			return parseLLMJudgeResponse(text);
 		} catch (error) {
 			_lastError = error instanceof Error ? error : new Error(String(error));
 			if (attempt < maxRetries) {
@@ -191,7 +203,7 @@ export async function evaluateLLMJudge(
 			}
 		}
 	}
-	return 0;
+	throw _lastError ?? new Error("Judge failed without returning a result");
 }
 
 /**

--- a/benchmark/longmemeval/src/opencontext-client.ts
+++ b/benchmark/longmemeval/src/opencontext-client.ts
@@ -12,6 +12,8 @@
  * (OPENROUTER_API_KEY, OPENROUTER_ANSWER_MODEL).
  */
 
+import { tokenUsage, type TokenUsage } from "../../run-support";
+
 export const DEFAULT_OPENCONTEXT_PORT = 7421;
 
 export function getOpencontextBaseUrl(): string {
@@ -27,6 +29,11 @@ export function getAnswererModelIdentity(): string {
 		return `anthropic-compatible:${process.env.ANSWER_MODEL ?? "MiniMax-M3-highspeed"}`;
 	}
 	return `openrouter:${process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"}`;
+}
+
+export interface GeneratedAnswer {
+	text: string;
+	token_usage: TokenUsage;
 }
 
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
@@ -143,7 +150,7 @@ export async function searchMemory(
  * Fallback: OpenRouter chat completions:
  *   OPENROUTER_API_KEY / OPENROUTER_ANSWER_MODEL (default deepseek/deepseek-chat)
  */
-export async function generateAnswer(prompt: string, system?: string): Promise<string> {
+export async function generateAnswer(prompt: string, system?: string): Promise<GeneratedAnswer> {
 	const token = process.env.ANTHROPIC_AUTH_TOKEN;
 	if (token) {
 		const base = (process.env.ANTHROPIC_BASE_URL ?? "https://api.minimaxi.com/anthropic").replace(/\/+$/, "");
@@ -168,12 +175,16 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		}
 		const data = (await res.json()) as {
 			content?: Array<{ type: string; text?: string }>;
+			usage?: { input_tokens?: number; output_tokens?: number };
 		};
 		const text = (data.content ?? [])
 			.filter((b) => b.type === "text" && typeof b.text === "string")
 			.map((b) => b.text as string)
 			.join("");
-		return text || "(empty response)";
+		return {
+			text,
+			token_usage: tokenUsage(data.usage?.input_tokens, data.usage?.output_tokens, undefined),
+		};
 	}
 
 	const openrouterKey = process.env.OPENROUTER_API_KEY;
@@ -187,10 +198,13 @@ export async function generateAnswer(prompt: string, system?: string): Promise<s
 		apiKey: openrouterKey,
 		name: "openrouter",
 	});
-	const { text } = await generateText({
+	const { text, usage } = await generateText({
 		model: openrouter(process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"),
 		...(system ? { system } : {}),
 		prompt,
 	});
-	return text;
+	return {
+		text,
+		token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+	};
 }

--- a/benchmark/longmemeval/src/opencontext-client.ts
+++ b/benchmark/longmemeval/src/opencontext-client.ts
@@ -22,6 +22,13 @@ export function getOpencontextBaseUrl(): string {
 
 export const BENCH_USER_ID = "benchmark_user";
 
+export function getAnswererModelIdentity(): string {
+	if (process.env.ANTHROPIC_AUTH_TOKEN) {
+		return `anthropic-compatible:${process.env.ANSWER_MODEL ?? "MiniMax-M3-highspeed"}`;
+	}
+	return `openrouter:${process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"}`;
+}
+
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
 	let res: Response;
 	try {

--- a/benchmark/longmemeval/src/types.ts
+++ b/benchmark/longmemeval/src/types.ts
@@ -2,6 +2,8 @@
  * Types for LongMemEval benchmark evaluation.
  */
 
+import type { TokenUsage } from "../../run-support";
+
 /**
  * A single turn in a conversation session.
  */
@@ -34,11 +36,7 @@ export interface EvaluationResult {
 	total_questions: number;
 	correct_answers: number;
 	accuracy: number;
-	token_usage: {
-		prompt_tokens: number;
-		completion_tokens: number;
-		total_tokens: number;
-	};
+	token_usage: TokenUsage;
 	predictions: Prediction[];
 	error?: string;
 }
@@ -52,6 +50,7 @@ export interface Prediction {
 	answerer_model: string;
 	judge_model: string;
 	error?: string;
+	token_usage: TokenUsage;
 	question: string;
 	answer: string;
 	response: string;

--- a/benchmark/longmemeval/src/types.ts
+++ b/benchmark/longmemeval/src/types.ts
@@ -47,6 +47,11 @@ export interface EvaluationResult {
  * Prediction result for a single question.
  */
 export interface Prediction {
+	status: "completed" | "execution_error";
+	attempt: number;
+	answerer_model: string;
+	judge_model: string;
+	error?: string;
 	question: string;
 	answer: string;
 	response: string;

--- a/benchmark/longmemeval/tsconfig.json
+++ b/benchmark/longmemeval/tsconfig.json
@@ -1,6 +1,7 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"incremental": false,
 		"outDir": "./dist",
 		"rootDir": "./src"
 	},

--- a/benchmark/longmemeval/tsconfig.json
+++ b/benchmark/longmemeval/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"incremental": false,
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": ".."
 	},
 	"include": ["src/**/*"]
 }

--- a/benchmark/run-support.ts
+++ b/benchmark/run-support.ts
@@ -160,7 +160,9 @@ export async function collectPreflightErrors(options: PreflightOptions): Promise
 		try {
 			await checkWritablePath(path);
 		} catch (error) {
-			errors.push(`output/checkpoint path is not writable: ${error instanceof Error ? error.message : String(error)}`);
+			errors.push(
+				`output/checkpoint path is not writable: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 	}
 	return errors;
@@ -168,7 +170,8 @@ export async function collectPreflightErrors(options: PreflightOptions): Promise
 
 export async function runPreflight(options: PreflightOptions): Promise<void> {
 	const errors = await collectPreflightErrors(options);
-	if (errors.length > 0) throw new Error(`Benchmark preflight failed:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+	if (errors.length > 0)
+		throw new Error(`Benchmark preflight failed:\n${errors.map((error) => `- ${error}`).join("\n")}`);
 }
 
 export function getManifestPath(output: string | undefined, benchmarkDir: string, startedAt: string): string {

--- a/benchmark/run-support.ts
+++ b/benchmark/run-support.ts
@@ -1,0 +1,206 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants, createReadStream } from "node:fs";
+import { access, mkdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+const MAX_HASH_BYTES = 256 * 1024 * 1024;
+
+export interface TokenUsage {
+	prompt_tokens: number | null;
+	completion_tokens: number | null;
+	total_tokens: number | null;
+}
+
+export interface DatasetIdentity {
+	path: string;
+	size_bytes: number;
+	mtime_ms: number;
+	sha256: string | null;
+}
+
+export interface RunManifest {
+	schema_version: 1;
+	benchmark: string;
+	git_commit: string | null;
+	dataset: DatasetIdentity;
+	answerer_model: string;
+	judge_model: string;
+	retrieval: { strategy: string; top_k: number };
+	resume: boolean;
+	started_at: string;
+	finished_at: string;
+	wall_clock_ms: number;
+	token_usage: TokenUsage;
+	parameters: Record<string, unknown>;
+}
+
+interface PreflightOptions {
+	datasetPath: string;
+	writablePaths: string[];
+	parameterErrors: string[];
+	validateDataset: () => Promise<void>;
+	checkDaemon: () => Promise<void>;
+}
+
+export function unavailableTokenUsage(): TokenUsage {
+	return { prompt_tokens: null, completion_tokens: null, total_tokens: null };
+}
+
+export function zeroTokenUsage(): TokenUsage {
+	return { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+}
+
+export function tokenUsage(
+	promptTokens: number | undefined,
+	completionTokens: number | undefined,
+	totalTokens: number | undefined,
+): TokenUsage {
+	const prompt = promptTokens ?? null;
+	const completion = completionTokens ?? null;
+	return {
+		prompt_tokens: prompt,
+		completion_tokens: completion,
+		total_tokens: totalTokens ?? (prompt !== null && completion !== null ? prompt + completion : null),
+	};
+}
+
+export function sumTokenUsage(usages: Array<TokenUsage | undefined>): TokenUsage {
+	if (usages.length === 0) return zeroTokenUsage();
+	const sum = (key: keyof TokenUsage): number | null => {
+		const values = usages.map((usage) => usage?.[key] ?? null);
+		return values.some((value) => value === null)
+			? null
+			: (values as number[]).reduce((total, value) => total + value, 0);
+	};
+	return {
+		prompt_tokens: sum("prompt_tokens"),
+		completion_tokens: sum("completion_tokens"),
+		total_tokens: sum("total_tokens"),
+	};
+}
+
+async function sha256(path: string): Promise<string> {
+	const hash = createHash("sha256");
+	for await (const chunk of createReadStream(path)) hash.update(chunk);
+	return hash.digest("hex");
+}
+
+export async function getDatasetIdentity(path: string): Promise<DatasetIdentity> {
+	const absolutePath = resolve(path);
+	const info = await stat(absolutePath);
+	return {
+		path: absolutePath,
+		size_bytes: info.size,
+		mtime_ms: info.mtimeMs,
+		sha256: info.size <= MAX_HASH_BYTES ? await sha256(absolutePath) : null,
+	};
+}
+
+function getGitCommit(): string | null {
+	try {
+		return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8" }).trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+async function checkWritablePath(path: string): Promise<void> {
+	const absolutePath = resolve(path);
+	try {
+		const info = await stat(absolutePath);
+		if (info.isDirectory()) throw new Error(`expected a file path but found a directory: ${absolutePath}`);
+		await access(absolutePath, constants.W_OK);
+		return;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+
+	let candidate = dirname(absolutePath);
+	while (true) {
+		try {
+			await access(candidate, constants.W_OK);
+			return;
+		} catch {
+			const parent = dirname(candidate);
+			if (parent === candidate) throw new Error(`no writable parent directory for ${path}`);
+			candidate = parent;
+		}
+	}
+}
+
+export async function collectPreflightErrors(options: PreflightOptions): Promise<string[]> {
+	const errors = [...options.parameterErrors];
+	let datasetReadable = true;
+	try {
+		await access(resolve(options.datasetPath), constants.R_OK);
+	} catch {
+		datasetReadable = false;
+		errors.push(`dataset is missing or unreadable: ${resolve(options.datasetPath)}`);
+	}
+	if (datasetReadable) {
+		try {
+			await options.validateDataset();
+		} catch (error) {
+			errors.push(`dataset validation failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	try {
+		await options.checkDaemon();
+	} catch (error) {
+		errors.push(error instanceof Error ? error.message : String(error));
+	}
+	if (!process.env.ANTHROPIC_AUTH_TOKEN && !process.env.OPENROUTER_API_KEY) {
+		errors.push("answerer credential missing: set ANTHROPIC_AUTH_TOKEN or OPENROUTER_API_KEY");
+	}
+	if (!process.env.OPENROUTER_API_KEY) {
+		errors.push("judge credential missing: set OPENROUTER_API_KEY");
+	}
+	for (const path of [...new Set(options.writablePaths)]) {
+		try {
+			await checkWritablePath(path);
+		} catch (error) {
+			errors.push(`output/checkpoint path is not writable: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return errors;
+}
+
+export async function runPreflight(options: PreflightOptions): Promise<void> {
+	const errors = await collectPreflightErrors(options);
+	if (errors.length > 0) throw new Error(`Benchmark preflight failed:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+}
+
+export function getManifestPath(output: string | undefined, benchmarkDir: string, startedAt: string): string {
+	if (output) return `${output}.manifest.json`;
+	const stamp = startedAt.replace(/[:.]/g, "-");
+	return join(benchmarkDir, "results", `run-${stamp}.manifest.json`);
+}
+
+export async function writeRunManifest(
+	path: string,
+	input: Omit<RunManifest, "schema_version" | "git_commit" | "dataset" | "wall_clock_ms"> & {
+		datasetPath: string;
+	},
+): Promise<RunManifest> {
+	const started = Date.parse(input.started_at);
+	const finished = Date.parse(input.finished_at);
+	const manifest: RunManifest = {
+		schema_version: 1,
+		benchmark: input.benchmark,
+		git_commit: getGitCommit(),
+		dataset: await getDatasetIdentity(input.datasetPath),
+		answerer_model: input.answerer_model,
+		judge_model: input.judge_model,
+		retrieval: input.retrieval,
+		resume: input.resume,
+		started_at: input.started_at,
+		finished_at: input.finished_at,
+		wall_clock_ms: Math.max(0, finished - started),
+		token_usage: input.token_usage,
+		parameters: input.parameters,
+	};
+	await mkdir(dirname(resolve(path)), { recursive: true });
+	await writeFile(path, JSON.stringify(manifest, null, 2), "utf-8");
+	return manifest;
+}


### PR DESCRIPTION
## Summary

This PR restores a supported, reproducible, and unbiased smoke/baseline path for the existing benchmark suite.

It addresses the six confirmed benchmark issues:

- restores the tracked AML-compatible local retrieval orchestrator and its six existing textual benchmark entrypoints
- repairs the LongMemEval and BEAM TypeScript configurations
- prevents LoCoMo and LongMemEval resume behavior from selectively retrying incorrect answers
- maps BEAM `128k`, `500k`, `1m`, and `10m` scales to their actual upstream Hugging Face sources
- adds preflight checks before ingestion or provider calls
- records minimum reproducibility metadata, real wall-clock time, and available provider token usage

## Changes

### Benchmark entrypoints

- Added a tracked `benchmark/aml-local/retrieve.py`.
- Updated `run_aml_local.ps1` to use the supported orchestrator.
- Added offline fixtures and mock HTTP coverage for:
  - LongMemEval
  - LoCoMo
  - CLBench
  - BEAM
  - PersonaMem
  - ScriptMem
- Restored typechecking for LoCoMo, LongMemEval, and BEAM.

### BEAM dataset mapping

Added explicit mappings for:

- `128k` → `Mohammadta/BEAM`, split `100K`
- `500k` → `Mohammadta/BEAM`, split `500K`
- `1m` → `Mohammadta/BEAM`, split `1M`
- `10m` → `Mohammadta/BEAM-10M`, split `10M`

The bundled `sample` conversion remains fully offline.

### Resume behavior

- `--resume` now reuses every successfully completed and judged result, whether correct or incorrect.
- Only execution errors such as transport failures, empty responses, timeouts, or judge parse failures are retried.
- Checkpoints record the attempt and answerer/judge model identities.
- `--no-resume` performs a fresh run.
- Model-mismatched or legacy checkpoints are not silently reused.

### Preflight and run metadata

Preflight now checks the required dataset, daemon, credentials, Python dependencies, parameters, and writable output paths before ingestion or paid provider calls.

Run manifests record the code revision, dataset identity, model identities, retrieval configuration, resume mode, timestamps, wall-clock duration, and available token usage. Missing provider usage is represented as unavailable rather than a fabricated zero.

### CI and documentation

Added an offline benchmark smoke job covering:

- TypeScript typechecking and lint
- CLI `--help`
- BEAM sample conversion and source mapping tests
- AML fixture, mock HTTP, and contract tests
- deterministic checkpoint/resume tests
- preflight failure tests
- verification that smoke tests do not modify tracked files

Updated the benchmark documentation to match the supported commands, data sources, resume semantics, and the distinction between internal TypeScript evaluation, AML-compatible local evaluation, and hosted AML leaderboard evaluation.

## Validation

- `pnpm install --frozen-lockfile`
- package build completed successfully
- full workspace typecheck completed successfully
- Linux/LF Biome format check passed for 915 files
- LoCoMo lint and 9 deterministic tests passed
- LongMemEval lint and 6 deterministic tests passed
- BEAM lint, 5 mapping/conversion tests, and offline sample conversion passed
- AML retrieval tests passed for all six entrypoints
- AML contract fixtures passed
- all benchmark CLI `--help` checks passed without credentials
- clean-worktree benchmark smoke validation passed

## Scope

This PR does not:

- add or tune benchmarks
- change models, prompts, embeddings, retrieval `top_k`, or scoring methods
- update published benchmark scores
- run paid answerer or judge models
- download full benchmark datasets
- perform a hosted AML submission

Fixture, mock, typecheck, and smoke results are not presented as evidence that the full paid benchmarks have been executed.

Closes #24