### PR TITLE
feat(benchmark): add BEAM evidence tracing and 128k report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           pnpm --filter @melandlabs/benchmark-locomo test
           pnpm --filter @melandlabs/benchmark-longmemeval test
+          pnpm --filter @melandlabs/benchmark-beam test
           (cd benchmark/beam/dataset && python -m unittest test_convert.py)
           (cd benchmark/aml-local && python -m unittest test_retrieve.py)
       - name: Convert bundled BEAM sample without Hugging Face dependencies

--- a/benchmark/beam/.env.example
+++ b/benchmark/beam/.env.example
@@ -1,10 +1,12 @@
 # OpenContext memory daemon (started via `opencontext http`)
 # OPENCONTEXT_URL=http://127.0.0.1:7421
 
-# Answerer LLM — Anthropic-compatible endpoint (e.g. MiniMax)
+# Answerer LLM — leave ANTHROPIC_AUTH_TOKEN empty to use OpenRouter
 ANTHROPIC_AUTH_TOKEN=
 ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
 ANSWER_MODEL=MiniMax-M3-highspeed
 
-# Judge LLM (OpenRouter) — used by the nugget judge in metrics.ts
+# OpenRouter answerer + judge (recommended low-cost domestic Flash models)
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_ANSWER_MODEL=deepseek/deepseek-v4-flash-0731
+OPENROUTER_JUDGE_MODEL=qwen/qwen3.7-flash

--- a/benchmark/beam/README.md
+++ b/benchmark/beam/README.md
@@ -57,6 +57,7 @@ benchmark/beam/
 │   ├── dataset.ts              # JSON loader + scale/type/conversation filtering
 │   ├── prompts.ts              # BEAM_NUGGET_JUDGE_PROMPT (rubric + 1-shot)
 │   ├── metrics.ts              # evaluateNuggetJudge + calculateNuggetCategoryMetrics
+│   ├── diagnostics.ts          # source/chunk/retrieval/model-call diagnostic chain
 │   ├── scorer.ts               # 10-type map + OPENCONTEXT_CLAIM_MAP
 │   ├── opencontext-client.ts   # VERBATIM copy of longmemeval/src/opencontext-client.ts
 │   ├── evaluator.ts            # BeamEvaluator — chunked ingest (20 turns) + nugget judge
@@ -81,6 +82,20 @@ benchmark/beam/
 | Per-question score | `correct: bool`                       | `nugget_mean + nugget_pass (≥0.5)`                |
 
 ## CLI
+
+Copy `.env.example` to `.env` and configure the provider before running a paid
+evaluation. A low-cost domestic Flash pairing is:
+
+```dotenv
+ANTHROPIC_AUTH_TOKEN=
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_ANSWER_MODEL=deepseek/deepseek-v4-flash-0731
+OPENROUTER_JUDGE_MODEL=qwen/qwen3.7-flash
+```
+
+`OPENROUTER_JUDGE_MODEL` is required and controls the actual nugget-judge call;
+it is not fixed in code. If `ANTHROPIC_AUTH_TOKEN` is set, the Answerer instead
+uses `ANTHROPIC_BASE_URL` and `ANSWER_MODEL`.
 
 ```bash
 # Show help
@@ -122,8 +137,15 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
 Before ingest or model calls, the CLI checks the dataset and filters, daemon,
 credentials, output/checkpoint paths, and arguments. It reports all detected
 failures together and never prints credential values. `--help` does not run
-these checks. `--resume` reuses completed judge results regardless of pass/fail;
+these checks. `--resume` reuses completed judge results regardless of pass/fail
+only when the Answerer/Judge identities and normalized conversation fingerprint
+match the current run;
 `--no-resume` ignores existing checkpoints.
+
+Converted datasets must be regenerated after this diagnostic-chain change so
+the JSON retains upstream turn ids and `source_chat_ids`. Legacy checkpoints
+with an older `trace_schema_version` are ignored because they cannot provide the
+same evidence chain.
 
 ## Output JSON shape
 
@@ -136,6 +158,18 @@ these checks. `--resume` reuses completed judge results regardless of pass/fail;
   "categories_filter": null,
   "token_usage": { "prompt_tokens": 1000, "completion_tokens": 200, "total_tokens": 1200 },
   "run_manifest": { "schema_version": 1, "git_commit": "...", "wall_clock_ms": 12345, … },
+  "diagnostics": {
+    "mean_source_recall_at_k": 0.71,
+    "mean_retrievable_source_recall_at_k": 0.74,
+    "hit_at_k_rate": 0.82,
+    "mean_reciprocal_rank": 0.64,
+    "failure_stages": { "retrieval_miss": 12, "context_present_answer_failed": 8 }
+  },
+  "diagnostic_artifacts": {
+    "trace_schema_version": "1.1",
+    "trace": "results/beam_1m.trace.jsonl",
+    "chunks": "results/beam_1m.chunks.jsonl"
+  },
   "summary": {
     "count": 700,
     "nugget_mean": 0.62,
@@ -172,6 +206,24 @@ Provider usage is recorded when returned; unavailable values are `null`, never a
 fabricated zero. With `--output results.json`, the same manifest is also written
 to `results.json.manifest.json`; without `--output`, it is written under
 `results/`.
+
+When `--output` is set, the runner also writes:
+
+- `*.chunks.jsonl`: upstream turn ids → deterministic chunk/message id → exact
+  ingest batch and status.
+- `*.trace.jsonl`: conversation id/fingerprint, gold source ids (required,
+  available, missing, retrieved and missed), full ranked Top-K contents and
+  daemon score signals, exact Answerer/Judge prompts, model responses, timing,
+  usage, Judge raw/parse status, answer attribution, and a conservative failure
+  stage.
+
+The source mapping is diagnostic only. Questions without an upstream source id
+remain scoreable, but retrieval metrics are marked unavailable rather than
+inventing a gold mapping. Dataset-source coverage is reported separately so a
+bad upstream reference is not silently blamed on OpenContext retrieval.
+
+The diagnostic fields do not participate in scoring. Existing
+`nugget_scores`, `nugget_mean`, and `nugget_pass >= 0.5` behavior is unchanged.
 
 ## Smoke-test checklist
 
@@ -215,10 +267,10 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
 | 1m     |     35 | 700 |      5–9 h |   ~$25 |
 | 10m    |     10 | 200 |     8–15 h |   ~$40 |
 
-Estimate uses `qwen/qwen3.7-max` as judge + the configured answerer LLM
-(Anthropic-compatible endpoint, e.g. MiniMax-M3-highspeed; falls back to
-OpenRouter when `ANTHROPIC_AUTH_TOKEN` is unset). Judge retries are
-bounded at 3 attempts.
+Actual cost depends on `OPENROUTER_JUDGE_MODEL` and the configured Answerer
+(Anthropic-compatible endpoint when `ANTHROPIC_AUTH_TOKEN` is set; otherwise
+`OPENROUTER_ANSWER_MODEL`). The table is only a rough planning estimate. Judge
+retries are bounded at 3 attempts.
 
 ## Critical risks (acknowledged in design)
 

--- a/benchmark/beam/dataset/README.md
+++ b/benchmark/beam/dataset/README.md
@@ -34,12 +34,16 @@ pnpm --filter @melandlabs/benchmark-beam benchmark -- \
 
 `convert.py` uses an explicit mapping rather than deriving Hugging Face names:
 
-| Local scale | Repository | Config | Split |
-| ----------- | ---------- | ------ | ----- |
-| `128k` | `Mohammadta/BEAM` | `default` | `100K` |
-| `500k` | `Mohammadta/BEAM` | `default` | `500K` |
-| `1m` | `Mohammadta/BEAM` | `default` | `1M` |
-| `10m` | `Mohammadta/BEAM-10M` | `default` | `10M` |
+| Local scale | Repository | Config | Split | Pinned revision |
+| ----------- | ---------- | ------ | ----- | --------------- |
+| `128k` | `Mohammadta/BEAM` | `default` | `100K` | `3205395e897e7318c7b094ef4e6047b9b82dbb03` |
+| `500k` | `Mohammadta/BEAM` | `default` | `500K` | `3205395e897e7318c7b094ef4e6047b9b82dbb03` |
+| `1m` | `Mohammadta/BEAM` | `default` | `1M` | `3205395e897e7318c7b094ef4e6047b9b82dbb03` |
+| `10m` | `Mohammadta/BEAM-10M` | `default` | `10M` | `9b2096193fe74e2837e4713e483351e19817773c` |
+
+The converter writes this source identity and its converter schema version into
+the generated JSON. This gives large datasets a stable upstream identity even
+when the run manifest intentionally skips a full-file SHA256.
 
 Non-sample conversion checks `datasets`, `pyarrow`, arguments, and the output
 path before calling Hugging Face. `sample` never imports those dependencies.

--- a/benchmark/beam/dataset/convert.py
+++ b/benchmark/beam/dataset/convert.py
@@ -21,6 +21,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib.util
 import json
 import os
@@ -28,26 +29,32 @@ import sys
 from pathlib import Path
 from typing import Any
 
+CONVERTER_SCHEMA_VERSION = "2"
+
 BEAM_SOURCES: dict[str, dict[str, str]] = {
     "128k": {
         "repository": "Mohammadta/BEAM",
         "config": "default",
         "split": "100K",
+        "revision": "3205395e897e7318c7b094ef4e6047b9b82dbb03",
     },
     "500k": {
         "repository": "Mohammadta/BEAM",
         "config": "default",
         "split": "500K",
+        "revision": "3205395e897e7318c7b094ef4e6047b9b82dbb03",
     },
     "1m": {
         "repository": "Mohammadta/BEAM",
         "config": "default",
         "split": "1M",
+        "revision": "3205395e897e7318c7b094ef4e6047b9b82dbb03",
     },
     "10m": {
         "repository": "Mohammadta/BEAM-10M",
         "config": "default",
         "split": "10M",
+        "revision": "9b2096193fe74e2837e4713e483351e19817773c",
     },
 }
 
@@ -108,18 +115,50 @@ def normalize_turn(turn: dict[str, Any]) -> dict[str, Any]:
         or turn.get("value")
         or ""
     )
+    source_id = turn.get("id")
+    source_index = turn.get("index")
     return {
         "speaker": str(speaker),
         "text": str(text),
-        "timestamp": turn.get("timestamp") or turn.get("ts") or turn.get("time"),
+        "timestamp": (
+            turn.get("timestamp")
+            or turn.get("ts")
+            or turn.get("time")
+            or turn.get("time_anchor")
+        ),
+        "source_id": str(source_id) if source_id is not None else None,
+        "source_index": str(source_index) if source_index is not None else None,
     }
+
+
+def flatten_scalar_values(value: Any) -> list[str]:
+    """Flatten list/dict/scalar provenance fields without inventing ids."""
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        flattened: list[str] = []
+        for nested in value.values():
+            flattened.extend(flatten_scalar_values(nested))
+        return flattened
+    if isinstance(value, (list, tuple, set)):
+        flattened = []
+        for nested in value:
+            flattened.extend(flatten_scalar_values(nested))
+        return flattened
+    return [str(value)]
+
+
+def normalize_source_chat_ids(value: Any) -> list[str]:
+    """Drop published placeholder cells while preserving real upstream ids."""
+    placeholders = {"", "--", "none", "null", "n/a"}
+    return [item for item in flatten_scalar_values(value) if item.strip().lower() not in placeholders]
 
 
 def normalize_question(q: dict[str, Any], idx: int) -> dict[str, Any] | None:
     text = q.get("question") or q.get("query") or q.get("prompt")
     if not text:
         return None
-    atoms = q.get("atoms") or q.get("nuggets") or []
+    atoms = q.get("atoms") or q.get("nuggets") or q.get("rubric") or []
     if isinstance(atoms, str):
         atoms = [a.strip() for a in atoms.split("\n") if a.strip()]
     return {
@@ -127,31 +166,108 @@ def normalize_question(q: dict[str, Any], idx: int) -> dict[str, Any] | None:
         "category": str(q.get("category") or q.get("type") or "information_extraction"),
         "question": str(text),
         "atoms": [str(a) for a in atoms],
-        "gold_answer": q.get("gold_answer") or q.get("answer"),
+        "gold_answer": (
+            q.get("gold_answer")
+            or q.get("answer")
+            or q.get("ideal_answer")
+            or q.get("ideal_response")
+            or q.get("ideal_summary")
+            or q.get("expected_compliance")
+        ),
+        "source": {
+            "source_chat_ids": normalize_source_chat_ids(q.get("source_chat_ids")),
+            "conversation_references": flatten_scalar_values(
+                q.get("conversation_references") or q.get("conversation_reference")
+            ),
+            "plan_references": flatten_scalar_values(
+                q.get("plan_references") or q.get("plan_reference")
+            ),
+            "why_unanswerable": q.get("why_unanswerable"),
+        },
     }
+
+
+def flatten_chat_turns(chat: Any) -> list[dict[str, Any]]:
+    """Flatten the published chat layouts into an ordered turn list."""
+    turns: list[dict[str, Any]] = []
+
+    def visit(item: Any) -> None:
+        if isinstance(item, list):
+            for child in item:
+                visit(child)
+            return
+        if not isinstance(item, dict):
+            return
+        if any(key in item for key in ("text", "content", "message", "value")):
+            turns.append(item)
+            return
+        if "turns" in item:
+            visit(item["turns"])
+            return
+        for child in item.values():
+            if isinstance(child, (dict, list)):
+                visit(child)
+
+    visit(chat)
+    return turns
 
 
 def normalize_conversation(conv: dict[str, Any], idx: int, scale: str) -> dict[str, Any] | None:
     chat = conv.get("chat") or conv.get("turns") or conv.get("messages") or []
     if not chat:
         return None
-    questions = (
+    raw_questions = (
         conv.get("probing_questions")
         or conv.get("questions")
         or conv.get("evaluation_questions")
         or []
     )
+
+    if isinstance(raw_questions, str):
+        try:
+            raw_questions = ast.literal_eval(raw_questions)
+        except (SyntaxError, ValueError) as error:
+            raise ValueError("probing_questions is not a valid serialized literal") from error
+
+    questions: list[dict[str, Any]] = []
+    if isinstance(raw_questions, dict):
+        for category, category_questions in raw_questions.items():
+            if not isinstance(category_questions, list):
+                raise ValueError(f"probing_questions category '{category}' is not a list")
+            for question in category_questions:
+                if not isinstance(question, dict):
+                    raise ValueError(f"probing_questions category '{category}' contains a non-object")
+                questions.append({**question, "category": question.get("category") or str(category)})
+    elif isinstance(raw_questions, list):
+        if not all(isinstance(question, dict) for question in raw_questions):
+            raise ValueError("probing_questions contains a non-object")
+        questions = raw_questions
+    else:
+        raise ValueError("probing_questions must be a list, mapping, or serialized mapping")
+
+    turns = flatten_chat_turns(chat)
+    if not turns:
+        raise ValueError("chat does not contain any recognizable turns")
+
+    entry_id = str(
+        conv.get("entry_id")
+        or conv.get("id")
+        or conv.get("conversation_id")
+        or f"conv_{idx}"
+    )
     normalized_questions = []
     for i, q in enumerate(questions):
         nq = normalize_question(q, i)
         if nq is not None:
+            if not (q.get("question_id") or q.get("id")):
+                nq["question_id"] = f"{scale}_{entry_id}_q_{i}"
             normalized_questions.append(nq)
     if not normalized_questions:
         return None
     return {
-        "entry_id": str(conv.get("entry_id") or conv.get("id") or conv.get("conversation_id") or f"conv_{idx}"),
+        "entry_id": entry_id,
         "scale": scale,
-        "chat": [normalize_turn(t) for t in chat],
+        "chat": [normalize_turn(turn) for turn in turns],
         "probing_questions": normalized_questions,
     }
 
@@ -181,23 +297,44 @@ def convert_hf_split(
         source["repository"],
         source["config"],
         split=source["split"],
+        revision=source["revision"],
     )
     print(f"  -> {len(ds)} raw rows")
 
-    out: list[dict[str, Any]] = []
-    for i, row in enumerate(ds):
-        conv = normalize_conversation(row, i, scale)
-        if conv is not None:
-            out.append(conv)
-        if max_conversations is not None and len(out) >= max_conversations:
-            break
-        if (i + 1) % 50 == 0:
-            print(f"  processed {i + 1} rows, kept {len(out)}...")
+    # Write one normalized conversation at a time. The 10M split is several
+    # hundred MB compressed and can exhaust memory if converted into one large
+    # Python list before serialization.
+    temp_path = out_path.with_suffix(f"{out_path.suffix}.tmp")
+    kept = 0
+    try:
+        with temp_path.open("w", encoding="utf-8") as output:
+            header = {
+                "scale": scale,
+                "source": {
+                    **source,
+                    "converter_schema_version": CONVERTER_SCHEMA_VERSION,
+                },
+            }
+            output.write(json.dumps(header, ensure_ascii=False)[:-1])
+            output.write(', "conversations": [')
+            for i, row in enumerate(ds):
+                conv = normalize_conversation(row, i, scale)
+                if conv is not None:
+                    if kept > 0:
+                        output.write(",")
+                    output.write(json.dumps(conv, ensure_ascii=False))
+                    kept += 1
+                if max_conversations is not None and kept >= max_conversations:
+                    break
+                if (i + 1) % 50 == 0:
+                    print(f"  processed {i + 1} rows, kept {kept}...")
+            output.write("]}")
+        temp_path.replace(out_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
 
-    payload = {"scale": scale, "conversations": out}
-    out_path.write_text(json.dumps(payload, ensure_ascii=False))
-    print(f"[ok] Wrote {len(out)} conversations -> {out_path} ({out_path.stat().st_size / 1_000_000:.1f} MB)")
-    return len(out)
+    print(f"[ok] Wrote {kept} conversations -> {out_path} ({out_path.stat().st_size / 1_000_000:.1f} MB)")
+    return kept
 
 
 def write_sample(out_path: Path) -> int:
@@ -209,14 +346,14 @@ def write_sample(out_path: Path) -> int:
                 "entry_id": "sample_001",
                 "scale": "sample",
                 "chat": [
-                    {"speaker": "user", "text": "Hey, I just moved to Berlin last week.", "timestamp": "2024-05-01T10:00:00Z"},
-                    {"speaker": "assistant", "text": "Welcome! How are you finding it so far?", "timestamp": "2024-05-01T10:00:05Z"},
-                    {"speaker": "user", "text": "Pretty good. I started a new job at a fintech on Tuesday.", "timestamp": "2024-05-01T10:01:00Z"},
-                    {"speaker": "assistant", "text": "Nice — what kind of role?", "timestamp": "2024-05-01T10:01:10Z"},
-                    {"speaker": "user", "text": "I'm a backend engineer, mostly Go and Postgres.", "timestamp": "2024-05-01T10:01:30Z"},
-                    {"speaker": "assistant", "text": "Cool. Anything fun planned for the weekend?", "timestamp": "2024-05-01T10:02:00Z"},
-                    {"speaker": "user", "text": "I think I'm going to check out the flea market at Mauerpark on Saturday.", "timestamp": "2024-05-04T09:00:00Z"},
-                    {"speaker": "assistant", "text": "Mauerpark on a Saturday is iconic — you'll love it.", "timestamp": "2024-05-04T09:00:30Z"},
+                    {"speaker": "user", "text": "Hey, I just moved to Berlin last week.", "timestamp": "2024-05-01T10:00:00Z", "source_id": "0"},
+                    {"speaker": "assistant", "text": "Welcome! How are you finding it so far?", "timestamp": "2024-05-01T10:00:05Z", "source_id": "1"},
+                    {"speaker": "user", "text": "Pretty good. I started a new job at a fintech on Tuesday.", "timestamp": "2024-05-01T10:01:00Z", "source_id": "2"},
+                    {"speaker": "assistant", "text": "Nice — what kind of role?", "timestamp": "2024-05-01T10:01:10Z", "source_id": "3"},
+                    {"speaker": "user", "text": "I'm a backend engineer, mostly Go and Postgres.", "timestamp": "2024-05-01T10:01:30Z", "source_id": "4"},
+                    {"speaker": "assistant", "text": "Cool. Anything fun planned for the weekend?", "timestamp": "2024-05-01T10:02:00Z", "source_id": "5"},
+                    {"speaker": "user", "text": "I think I'm going to check out the flea market at Mauerpark on Saturday.", "timestamp": "2024-05-04T09:00:00Z", "source_id": "6"},
+                    {"speaker": "assistant", "text": "Mauerpark on a Saturday is iconic — you'll love it.", "timestamp": "2024-05-04T09:00:30Z", "source_id": "7"},
                 ],
                 "probing_questions": [
                     {
@@ -225,12 +362,17 @@ def write_sample(out_path: Path) -> int:
                         "question": "What city did the user recently move to?",
                         "atoms": ["Berlin"],
                         "gold_answer": "Berlin",
+                        "source": {
+                            "source_chat_ids": ["0"],
+                            "conversation_references": ["chat_id: 0"],
+                            "plan_references": [],
+                        },
                     }
                 ],
             }
         ],
     }
-    out_path.write_text(json.dumps(sample, indent=2, ensure_ascii=False))
+    out_path.write_text(json.dumps(sample, indent=2, ensure_ascii=False), encoding="utf-8")
     print(f"[ok] Wrote sample -> {out_path}")
     return 1
 

--- a/benchmark/beam/dataset/sample_conversation.json
+++ b/benchmark/beam/dataset/sample_conversation.json
@@ -8,42 +8,50 @@
 				{
 					"speaker": "user",
 					"text": "Hey, I just moved to Berlin last week.",
-					"timestamp": "2024-05-01T10:00:00Z"
+					"timestamp": "2024-05-01T10:00:00Z",
+					"source_id": "0"
 				},
 				{
 					"speaker": "assistant",
 					"text": "Welcome! How are you finding it so far?",
-					"timestamp": "2024-05-01T10:00:05Z"
+					"timestamp": "2024-05-01T10:00:05Z",
+					"source_id": "1"
 				},
 				{
 					"speaker": "user",
 					"text": "Pretty good. I started a new job at a fintech on Tuesday.",
-					"timestamp": "2024-05-01T10:01:00Z"
+					"timestamp": "2024-05-01T10:01:00Z",
+					"source_id": "2"
 				},
 				{
 					"speaker": "assistant",
 					"text": "Nice — what kind of role?",
-					"timestamp": "2024-05-01T10:01:10Z"
+					"timestamp": "2024-05-01T10:01:10Z",
+					"source_id": "3"
 				},
 				{
 					"speaker": "user",
 					"text": "I'm a backend engineer, mostly Go and Postgres.",
-					"timestamp": "2024-05-01T10:01:30Z"
+					"timestamp": "2024-05-01T10:01:30Z",
+					"source_id": "4"
 				},
 				{
 					"speaker": "assistant",
 					"text": "Cool. Anything fun planned for the weekend?",
-					"timestamp": "2024-05-01T10:02:00Z"
+					"timestamp": "2024-05-01T10:02:00Z",
+					"source_id": "5"
 				},
 				{
 					"speaker": "user",
 					"text": "I think I'm going to check out the flea market at Mauerpark on Saturday.",
-					"timestamp": "2024-05-04T09:00:00Z"
+					"timestamp": "2024-05-04T09:00:00Z",
+					"source_id": "6"
 				},
 				{
 					"speaker": "assistant",
 					"text": "Mauerpark on a Saturday is iconic — you'll love it.",
-					"timestamp": "2024-05-04T09:00:30Z"
+					"timestamp": "2024-05-04T09:00:30Z",
+					"source_id": "7"
 				}
 			],
 			"probing_questions": [
@@ -52,7 +60,12 @@
 					"category": "information_extraction",
 					"question": "What city did the user recently move to?",
 					"atoms": ["Berlin"],
-					"gold_answer": "Berlin"
+					"gold_answer": "Berlin",
+					"source": {
+						"source_chat_ids": ["0"],
+						"conversation_references": ["chat_id: 0"],
+						"plan_references": []
+					}
 				}
 			]
 		}

--- a/benchmark/beam/dataset/test_convert.py
+++ b/benchmark/beam/dataset/test_convert.py
@@ -13,14 +13,134 @@ import convert
 
 
 EXPECTED_SOURCES = {
-    "128k": ("Mohammadta/BEAM", "default", "100K"),
-    "500k": ("Mohammadta/BEAM", "default", "500K"),
-    "1m": ("Mohammadta/BEAM", "default", "1M"),
-    "10m": ("Mohammadta/BEAM-10M", "default", "10M"),
+    "128k": ("Mohammadta/BEAM", "default", "100K", "3205395e897e7318c7b094ef4e6047b9b82dbb03"),
+    "500k": ("Mohammadta/BEAM", "default", "500K", "3205395e897e7318c7b094ef4e6047b9b82dbb03"),
+    "1m": ("Mohammadta/BEAM", "default", "1M", "3205395e897e7318c7b094ef4e6047b9b82dbb03"),
+    "10m": ("Mohammadta/BEAM-10M", "default", "10M", "9b2096193fe74e2837e4713e483351e19817773c"),
 }
 
 
 class BeamSourceMappingTests(unittest.TestCase):
+    def test_normalizes_the_published_nested_chat_and_serialized_questions(self) -> None:
+        fixture = {
+            "conversation_id": "real-shape",
+            "chat": [
+                [
+                    {
+                        "role": "user",
+                        "content": "Remember Berlin.",
+                        "time_anchor": "March-15-2024",
+                        "id": 41,
+                        "index": "1,1",
+                    }
+                ],
+                [
+                    {
+                        "role": "assistant",
+                        "content": "I will remember that.",
+                        "time_anchor": "March-16-2024",
+                    }
+                ],
+            ],
+            "probing_questions": repr(
+                {
+                    "information_extraction": [
+                        {
+                            "question": "Which city?",
+                            "answer": "Berlin",
+                            "rubric": ["The answer identifies Berlin"],
+                            "source_chat_ids": {"answer": [41]},
+                            "conversation_reference": "chat_id: 41",
+                        }
+                    ],
+                    "abstention": [
+                        {
+                            "question": "Which university?",
+                            "ideal_response": "The conversation does not say.",
+                            "rubric": ["The answer abstains"],
+                            "why_unanswerable": "No university is mentioned.",
+                            "plan_reference": "Batch 1, Bullet 2",
+                        }
+                    ],
+                }
+            ),
+        }
+
+        conversation = convert.normalize_conversation(fixture, 0, "128k")
+
+        self.assertIsNotNone(conversation)
+        assert conversation is not None
+        self.assertEqual(conversation["entry_id"], "real-shape")
+        self.assertEqual(len(conversation["chat"]), 2)
+        self.assertEqual(conversation["chat"][0]["timestamp"], "March-15-2024")
+        self.assertEqual(conversation["chat"][0]["source_id"], "41")
+        self.assertEqual(conversation["chat"][0]["source_index"], "1,1")
+        self.assertEqual(
+            [question["question_id"] for question in conversation["probing_questions"]],
+            ["128k_real-shape_q_0", "128k_real-shape_q_1"],
+        )
+        self.assertEqual(
+            conversation["probing_questions"][0],
+            {
+                "question_id": "128k_real-shape_q_0",
+                "category": "information_extraction",
+                "question": "Which city?",
+                "atoms": ["The answer identifies Berlin"],
+                "gold_answer": "Berlin",
+                "source": {
+                    "source_chat_ids": ["41"],
+                    "conversation_references": ["chat_id: 41"],
+                    "plan_references": [],
+                    "why_unanswerable": None,
+                },
+            },
+        )
+        self.assertEqual(
+            conversation["probing_questions"][1]["gold_answer"],
+            "The conversation does not say.",
+        )
+        self.assertEqual(
+            conversation["probing_questions"][1]["source"],
+            {
+                "source_chat_ids": [],
+                "conversation_references": [],
+                "plan_references": ["Batch 1, Bullet 2"],
+                "why_unanswerable": "No university is mentioned.",
+            },
+        )
+
+    def test_flattens_the_published_10m_plan_batches(self) -> None:
+        chat = [
+            {
+                "plan-1": [
+                    {
+                        "batch_number": 1,
+                        "time_anchor": None,
+                        "turns": [
+                            [
+                                {"role": "user", "content": "First"},
+                                {"role": "assistant", "content": "Second"},
+                            ]
+                        ],
+                    }
+                ]
+            },
+            {
+                "plan-2": [
+                    {
+                        "batch_number": 2,
+                        "time_anchor": None,
+                        "turns": [[{"role": "user", "content": "Third"}]],
+                    }
+                ]
+            },
+        ]
+
+        self.assertEqual(
+            [turn["content"] for turn in convert.flatten_chat_turns(chat)],
+            ["First", "Second", "Third"],
+        )
+
     def test_non_sample_preflight_reports_all_missing_dependencies_and_bad_limit(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             with patch.object(importlib.util, "find_spec", return_value=None):
@@ -44,7 +164,7 @@ class BeamSourceMappingTests(unittest.TestCase):
     def test_all_scales_use_the_expected_hugging_face_source(self) -> None:
         fixture = {
             "conversation_id": "fixture-conversation",
-            "chat": [{"role": "user", "content": "Remember Berlin."}],
+            "chat": [{"role": "user", "content": "Remember the 10 m² Berlin office."}],
             "probing_questions": [
                 {
                     "id": "fixture-question",
@@ -58,15 +178,16 @@ class BeamSourceMappingTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             for scale, expected_source in EXPECTED_SOURCES.items():
                 with self.subTest(scale=scale):
-                    calls: list[tuple[str, str, str]] = []
+                    calls: list[tuple[str, str, str, str]] = []
 
                     def fake_load_dataset(
                         repository: str,
                         config: str,
                         *,
                         split: str,
+                        revision: str,
                     ) -> list[dict[str, object]]:
-                        calls.append((repository, config, split))
+                        calls.append((repository, config, split, revision))
                         return [fixture]
 
                     output = Path(temp_dir) / f"beam_{scale}.json"
@@ -79,9 +200,16 @@ class BeamSourceMappingTests(unittest.TestCase):
 
                     self.assertEqual(calls, [expected_source])
                     self.assertEqual(converted, 1)
-                    payload = json.loads(output.read_text())
+                    payload = json.loads(output.read_text(encoding="utf-8"))
                     self.assertEqual(payload["scale"], scale)
+                    self.assertEqual(payload["source"]["revision"], expected_source[3])
                     self.assertEqual(payload["conversations"][0]["scale"], scale)
+
+    def test_source_chat_id_placeholders_are_not_treated_as_gold_ids(self) -> None:
+        self.assertEqual(
+            convert.normalize_source_chat_ids([41, "--", None, "N/A", "  "]),
+            ["41"],
+        )
 
     def test_unknown_scale_fails_before_loading_a_dataset(self) -> None:
         calls = 0
@@ -122,7 +250,7 @@ class BeamSourceMappingTests(unittest.TestCase):
                 convert.main()
 
             payload = json.loads(
-                (Path(temp_dir) / "sample_conversation.json").read_text()
+                (Path(temp_dir) / "sample_conversation.json").read_text(encoding="utf-8")
             )
             self.assertEqual(payload["scale"], "sample")
             self.assertEqual(len(payload["conversations"]), 1)

--- a/benchmark/beam/docs/128k-v1-test-report.md
+++ b/benchmark/beam/docs/128k-v1-test-report.md
@@ -1,0 +1,239 @@
+# BEAM 128k 第一次完整测试报告
+
+- 报告版本：v1
+- 测试状态：诊断基线，暂不作为正式性能基线
+- 数据规格：BEAM `128k`
+- 完成时间：2026-09-01 06:22
+- 原始结果：[beam-128k-v1_1-full-20260831.json](../results/beam-128k-v1_1-full-20260831.json)
+- 完整链路：[beam-128k-v1_1-full-20260831.trace.jsonl](../results/beam-128k-v1_1-full-20260831.trace.jsonl)
+- 分块记录：[beam-128k-v1_1-full-20260831.chunks.jsonl](../results/beam-128k-v1_1-full-20260831.chunks.jsonl)
+
+> `results/`、checkpoint 和数据库文件默认被 `.gitignore` 排除。本报告记录可提交的结果摘要；原始文件需要单独保留。
+
+## 1. 测试目的
+
+本次测试用于验证 OpenContext 在 BEAM 128k 长对话上的端到端记忆问答表现，并通过完整链路区分以下问题：
+
+1. 数据集是否提供了可用的 gold source；
+2. 对话是否正确进入 OpenContext；
+3. Top-K 是否召回 gold source；
+4. Answerer 是否利用已召回证据正确作答；
+5. Judge 是否按 nugget atoms 完成评分。
+
+本报告不会把端到端分数直接解释为纯检索能力，也不会把 Answerer、Judge 或 benchmark adapter 的问题直接归因于 OpenContext 核心 memory 实现。
+
+## 2. 测试配置
+
+| 项目 | 配置 |
+|---|---|
+| 数据集 | `dataset/beam_128k.json` |
+| 数据集大小 | 13,441,553 bytes |
+| 数据集 SHA-256 | `8cc3374c9f258bfa91df3f7a0d5d7c9ade64dd704a723829c2095dbeabb43d7e` |
+| 上游数据 | `Mohammadta/BEAM`, config `default`, split `100K` |
+| 上游 revision | `3205395e897e7318c7b094ef4e6047b9b82dbb03` |
+| 会话数 | 20 |
+| 问题数 | 400，每类 40 题 |
+| Answerer | `openrouter:deepseek/deepseek-v4-flash-0731` |
+| Judge | `openrouter:qwen/qwen3.7-flash` |
+| 检索 | `memory-search`, Top-K=8 |
+| 对话分块 | 每 20 turns 一个 memory message |
+| trace schema | `1.1` |
+| manifest commit | `d722484d759f176c269523fe9958ce75a8f78956` |
+| resume | `true` |
+
+结果 manifest 没有记录 daemon 的 memory backend、embedding provider/model、embedding token limit、merge strategy、数据库路径或 Git dirty state。因此，仅凭 manifest 还不能完整重建本次 daemon 和实际工作树配置。这是本次结果的复现限制之一。
+
+## 3. 执行完整性与成本规模
+
+| 指标 | 结果 |
+|---|---:|
+| 已完成问题 | 400 / 400 |
+| execution error | 0 |
+| wall-clock | 942,760 ms，约 15 分 43 秒 |
+| prompt tokens | 30,046,468 |
+| completion tokens | 1,409,917 |
+| total tokens | 31,456,385 |
+| 平均每题 total tokens | 约 78,641 |
+
+Provider token usage 已完整返回，但本报告不估算货币成本，因为实际费用取决于 OpenRouter 当时的模型定价和账户路由。
+
+## 4. 总体结果
+
+| 指标 | 结果 |
+|---|---:|
+| Nugget Mean | 0.5305 |
+| Pass Count | 227 / 400 |
+| Pass Rate | 56.75% |
+| 未通过 | 173 / 400 |
+
+本次 400 题全部获得 Answerer 和 Judge 结果，因此结果足以用于问题定位。但由于检索通道、分块和复现信息仍存在下述问题，当前分数只作为第一次诊断基线。
+
+## 5. 分类结果
+
+| 分类 | Nugget Mean | Pass Rate | 通过数 |
+|---|---:|---:|---:|
+| abstention | 0.8250 | 82.50% | 33 / 40 |
+| preference_following | 0.7146 | 80.00% | 32 / 40 |
+| information_extraction | 0.6292 | 65.00% | 26 / 40 |
+| contradiction_resolution | 0.4906 | 60.00% | 24 / 40 |
+| instruction_following | 0.5563 | 57.50% | 23 / 40 |
+| multi_session_reasoning | 0.4855 | 52.50% | 21 / 40 |
+| summarization | 0.4341 | 52.50% | 21 / 40 |
+| temporal_reasoning | 0.4500 | 50.00% | 20 / 40 |
+| knowledge_update | 0.4750 | 47.50% | 19 / 40 |
+| event_ordering | 0.2444 | 20.00% | 8 / 40 |
+
+表现较好的类型是 abstention、preference following 和 information extraction。最弱的是 event ordering，其次是 summarization、temporal reasoning 和 knowledge update。总体趋势表明：单点事实和拒答相对稳定，多证据组合、时间顺序和新旧信息更新明显较弱。
+
+## 6. 检索链路结果
+
+以下指标只统计具有 upstream gold source IDs 的 355 题：
+
+| 指标 | 结果 | 含义 |
+|---|---:|---|
+| Hit@8 | 92.11% | Top-8 中至少出现一个 gold source |
+| Mean Source Recall@8 | 0.8027 | 平均召回约 80.27% 的必要 source turns |
+| All Required Sources Retrieved | 65.35% | 所有必要 source 都进入 Top-8 |
+| Precision@8 | 0.2011 | Top-8 中真正覆盖 gold source 的块比例较低 |
+| MRR | 0.2958 | 第一个相关块通常排序不够靠前 |
+| Dataset Source Coverage | 1.0000 | 有 source ID 的题目，其 ID 均能在数据集中找到 |
+
+这说明检索通常能找到至少一条相关证据，但在需要多个事件或多个会话证据的题目上，经常只召回部分证据；同时 Top-8 中包含较多无关内容。
+
+### 6.1 最终结果几乎只有 lexical 信号
+
+400 题共返回 3,200 个 Top-K hits：
+
+- `lexical-only`：3,199；
+- `lexical + semantic`：1；
+- `semantic-only`：0。
+
+因此，本次实际送入 Answerer 的最终证据几乎完全由 lexical 通道提供。现有 trace 只记录合并后的 Top-K，没有记录 semantic 和 lexical 的合并前候选列表，所以暂时无法判断：
+
+1. semantic ANN 没有返回候选；还是
+2. semantic 候选存在，但被 merge/ranking 阶段全部淘汰。
+
+在查清这一点之前，不能将本次结果视为对 OpenContext semantic memory 的有效测量。
+
+### 6.2 分块明显大于本地 embedding 输入范围
+
+当前 [evaluator.ts](../src/evaluator.ts) 固定每 20 turns 生成一个 memory message。本次共有 296 个块：
+
+| chunk 字符数 | 结果 |
+|---|---:|
+| 平均 | 41,712 |
+| P50 | 40,834 |
+| P95 | 58,259 |
+| 最大 | 376,965 |
+
+仓库当前 [local-transformers-embedding-provider.ts](../../../packages/ai/rag/src/local-transformers-embedding-provider.ts) 的默认 `maxTokens` 是 512，并显式启用 tokenizer truncation。如果 daemon 使用该本地 embedding 路径，一个数万字符块不可能被完整表示，后半部分信息不会参与该块的 embedding。
+
+由于本次 manifest 没有记录实际 embedding provider 和 token limit，这一点应视为高风险配置问题，而不是已经由 artifact 完全证明的唯一根因。
+
+## 7. Answerer 链路结果
+
+Answerer 每题收到 8 个完整 memory chunks：
+
+| Answerer 输入 | 结果 |
+|---|---:|
+| 平均 context 字符数 | 343,439 |
+| 平均 prompt tokens | 74,191 |
+| P50 prompt tokens | 71,928 |
+| P95 prompt tokens | 100,504 |
+| 最大 prompt tokens | 105,620 |
+
+输入虽然没有触发 execution error，但上下文非常大、无关证据比例较高。模型需要在约 7 万至 10 万 tokens 中寻找少量关键事实，既增加费用，也会降低时间顺序、冲突更新和多证据综合的稳定性。
+
+### 7.1 失败阶段
+
+| Failure Stage | 数量 | 解释 |
+|---|---:|---|
+| `context_present_answer_failed` | 94 | 全部 gold sources 已进入 Top-K，但最终答案未通过 |
+| `retrieval_partial` | 64 | 只召回部分必要 sources |
+| `retrieval_miss` | 14 | 没有召回任何 gold source |
+| `dataset_reference_missing` | 1 | 上游题目没有提供 source IDs |
+| `none` | 227 | 通过 |
+
+`context_present_answer_failed` 的 94 题不等于“OpenContext 检索正确、只有模型错误”。它只表示 gold source 所在的大块进入了 prompt；在超大块和超大 prompt 下，关键内容仍可能被噪声掩盖。此类失败主要集中在：
+
+- knowledge update：18；
+- contradiction resolution：13；
+- temporal reasoning：13；
+- instruction following：12；
+- multi-session reasoning：10。
+
+这部分需要用更小的证据单元或 gold-evidence 对照实验，才能继续区分上下文构建与 Answerer 能力。
+
+## 8. 引用与评判链路问题
+
+在 355 个需要 source evidence 的问题中：
+
+| Attribution | 数量 | 比例 |
+|---|---:|---:|
+| supported | 153 | 43.10% |
+| unsupported | 110 | 30.99% |
+| uncited | 92 | 25.92% |
+
+当前 [diagnostics.ts](../src/diagnostics.ts) 只识别 `Excerpt 3`、`Memory excerpt 3` 或 `[3]` 形式。Answerer 如果直接输出 `beam_9__chunk_1` 等真实 chunk ID，仍可能被标记为 `uncited`。因此 attribution 结果可以用于发现问题，但暂时不能作为精确的引用正确率。
+
+此外至少确认了两类数据质量问题：
+
+1. `128k_18_q_16` 没有 upstream source IDs，无法计算检索归因；
+2. `128k_1_q_18` 的 gold answer 写的是 `4 weeks`，nugget atom 要求 `8 weeks`。Judge 按 atom 打分，因此该题的失败不能直接归因于 Answerer 或 memory。
+
+Answerer 与 Judge 使用不同模型本身不是问题。当前主要风险是 Answerer 的输入组织，以及原始 atoms/source references 的一致性。Judge 模型的稳定性仍应通过抽样复核验证。
+
+## 9. 当前结论
+
+本次测试可以得出以下结论：
+
+1. 128k 的 400 题端到端流程已经完整执行，没有 provider 或执行错误；
+2. 当前路径擅长拒答、偏好和单点事实提取；
+3. event ordering、多会话综合、时间推理和知识更新是主要弱项；
+4. 多证据完整召回和排序质量不足；
+5. 最终 Top-K 几乎为 lexical-only，semantic retrieval 是否有效仍未得到证明；
+6. 20-turn 大块和平均约 74k tokens 的 Answerer prompt 是明显的效率与质量风险；
+7. 部分失败来自 benchmark 数据引用或 atom 不一致，不能全部计入 OpenContext 缺陷。
+
+因此，本次结果应保留为“BEAM 128k diagnostic baseline v1”，不应直接用于对外宣称 OpenContext 的正式 BEAM 成绩，也不适合与其他 agent 的公开成绩直接比较。
+
+## 10. 改善建议
+
+按优先级执行最小修复：
+
+### P0：确认 semantic 检索真实生效
+
+1. benchmark 请求显式指定并记录 merge strategy；
+2. trace 记录 semantic、lexical 合并前候选数量及最终通道占比；
+3. manifest 记录 daemon backend、embedding provider/model/max tokens、reasoning 配置和数据库身份；
+4. 正式运行前使用已知事实校准，要求 semantic 通道产生可验证候选，否则停止运行并报告。
+
+### P1：缩小检索单元和 Answerer 上下文
+
+1. 优先按单个 source turn 建立检索单元；
+2. 超长 turn 再按 token 切分，并保留同一 source ID；
+3. 让 embedding 输入稳定落在实际 token limit 内；
+4. Top-K 后去重、轻量 rerank，只向 Answerer 提供相关片段和必要相邻 turns；
+5. 保留时间戳和 source ID，对时间及事件顺序问题按时间组织证据；
+6. 为 Answerer prompt 设置明确预算，避免继续发送 7 万至 10 万 tokens 的原始块。
+
+### P2：完善诊断可靠性
+
+1. Answerer 使用结构化 citations，或让解析器支持实际 chunk ID；
+2. 运行前检查 source IDs、gold answer 和 nugget atoms 的数字、日期一致性；
+3. 对弱项分类抽取固定样本，分别运行实际检索上下文和 gold evidence，对比定位 retrieval/context/answerer；
+4. 对分层样本进行人工或更强 Judge 复核，但不修改原始 nugget 评分规则。
+
+## 11. 下一版 128k 的最低验收条件
+
+重新完整运行 128k 前，至少满足：
+
+- semantic 通道在校准查询和 trace 中可见，不再静默退化为近乎纯 lexical；
+- 检索单元不超过实际 embedding token limit；
+- manifest 能重建 daemon、embedding、merge strategy、数据库和工作树状态；
+- Answerer prompt 有明确预算，并报告平均值与 P95；
+- 使用新的空数据库和 `--no-resume`；
+- 保持原始 nugget scoring 不变，新增诊断字段不参与分数；
+- 完整运行仍需达到 400 / 400 completed、0 execution errors；
+- 原始总分、数据异常和链路指标分别报告，不能把无效 source/atom 问题计为 OpenContext 缺陷。
+

--- a/benchmark/beam/package.json
+++ b/benchmark/beam/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "tsx src/index.ts",
 		"benchmark": "tsx src/index.ts",
+		"test": "tsx --test src/*.test.ts",
 		"typecheck": "tsc --noEmit",
 		"lint": "node ../../node_modules/@biomejs/biome/bin/biome lint",
 		"lint:fix": "node ../../node_modules/@biomejs/biome/bin/biome lint --write --unsafe"

--- a/benchmark/beam/src/dataset.ts
+++ b/benchmark/beam/src/dataset.ts
@@ -11,6 +11,7 @@ import { readFile } from "node:fs/promises";
 import type {
 	BeamConversation,
 	BeamDatasetFile,
+	BeamDatasetSource,
 	BeamProbingQuestion,
 	BeamQuestionCategory,
 	BeamScale,
@@ -56,6 +57,11 @@ interface RawBeamTurn {
 	text?: string;
 	content?: string;
 	timestamp?: string;
+	time_anchor?: string;
+	source_id?: string | number;
+	id?: string | number;
+	source_index?: string | number;
+	index?: string | number;
 }
 
 interface RawBeamQuestion {
@@ -67,6 +73,12 @@ interface RawBeamQuestion {
 	nuggets?: string[];
 	gold_answer?: string;
 	answer?: string;
+	source?: Partial<BeamProbingQuestion["source"]>;
+	source_chat_ids?: unknown;
+	conversation_reference?: unknown;
+	conversation_references?: unknown;
+	plan_reference?: unknown;
+	why_unanswerable?: string;
 }
 
 interface RawBeamConversation {
@@ -81,7 +93,13 @@ interface RawBeamConversation {
 
 interface RawBeamDataset {
 	scale?: string;
+	source?: BeamDatasetSource;
 	conversations?: RawBeamConversation[];
+}
+
+export interface LoadedBeamDataset {
+	conversations: BeamConversation[];
+	source: BeamDatasetSource | null;
 }
 
 const VALID_CATEGORIES = new Set<BeamQuestionCategory>([
@@ -107,11 +125,27 @@ function normalizeCategory(raw: string | undefined): BeamQuestionCategory | null
 }
 
 function normalizeTurn(raw: RawBeamTurn): BeamTurn {
+	const sourceId = raw.source_id ?? raw.id;
+	const sourceIndex = raw.source_index ?? raw.index;
 	return {
 		speaker: raw.speaker ?? raw.role ?? "user",
 		text: raw.text ?? raw.content ?? "",
-		timestamp: raw.timestamp,
+		timestamp: raw.timestamp ?? raw.time_anchor,
+		source_id: sourceId === undefined ? undefined : String(sourceId),
+		source_index: sourceIndex === undefined ? undefined : String(sourceIndex),
 	};
+}
+
+function flattenScalarValues(value: unknown): string[] {
+	if (value === null || value === undefined) return [];
+	if (Array.isArray(value)) return value.flatMap(flattenScalarValues);
+	if (typeof value === "object") return Object.values(value).flatMap(flattenScalarValues);
+	return [String(value)];
+}
+
+function normalizeSourceChatIds(value: unknown): string[] {
+	const placeholders = new Set(["", "--", "none", "null", "n/a"]);
+	return flattenScalarValues(value).filter((item) => !placeholders.has(item.trim().toLowerCase()));
 }
 
 function normalizeQuestion(
@@ -135,6 +169,14 @@ function normalizeQuestion(
 		question: text,
 		atoms,
 		gold_answer: raw.gold_answer ?? raw.answer,
+		source: {
+			source_chat_ids: normalizeSourceChatIds(raw.source?.source_chat_ids ?? raw.source_chat_ids),
+			conversation_references: flattenScalarValues(
+				raw.source?.conversation_references ?? raw.conversation_references ?? raw.conversation_reference,
+			),
+			plan_references: flattenScalarValues(raw.source?.plan_references ?? raw.plan_reference),
+			why_unanswerable: raw.source?.why_unanswerable ?? raw.why_unanswerable,
+		},
 	};
 }
 
@@ -170,10 +212,10 @@ function normalizeConversation(
  * Parse + lightly validate a BEAM dataset JSON file.
  * Throws if the file shape is wrong; returns the typed object otherwise.
  */
-export async function loadBeamDatasetFromJson(
+export async function loadBeamDatasetWithMetadata(
 	jsonPath: string,
 	opts: LoadBeamOptions = {},
-): Promise<BeamConversation[]> {
+): Promise<LoadedBeamDataset> {
 	const content = await readFile(jsonPath, "utf-8");
 	let raw: RawBeamDataset | BeamConversation[];
 	try {
@@ -222,7 +264,17 @@ export async function loadBeamDatasetFromJson(
 		conversations = conversations.filter((c) => c.probing_questions.length > 0);
 	}
 
-	return conversations;
+	return {
+		conversations,
+		source: Array.isArray(raw) ? null : (raw.source ?? null),
+	};
+}
+
+export async function loadBeamDatasetFromJson(
+	jsonPath: string,
+	opts: LoadBeamOptions = {},
+): Promise<BeamConversation[]> {
+	return (await loadBeamDatasetWithMetadata(jsonPath, opts)).conversations;
 }
 
 /**

--- a/benchmark/beam/src/diagnostics.test.ts
+++ b/benchmark/beam/src/diagnostics.test.ts
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	buildAnswerAttribution,
+	buildRetrievalTrace,
+	calculateDiagnosticSummary,
+	deriveFailureStage,
+} from "./diagnostics";
+import { buildConversationMessages } from "./evaluator";
+import { summarizeNuggetScores } from "./metrics";
+import { IngestMessagesError, ingestMessages, searchMemory } from "./opencontext-client";
+import {
+	BEAM_TRACE_SCHEMA_VERSION,
+	type BeamProbingQuestion,
+	type BeamRetrievalTrace,
+	type Prediction,
+} from "./types";
+
+const question: BeamProbingQuestion = {
+	question_id: "q-1",
+	category: "information_extraction",
+	question: "Which city?",
+	atoms: ["Berlin"],
+	gold_answer: "Berlin",
+	source: {
+		source_chat_ids: ["41", "80"],
+		conversation_references: ["chat_id: 41", "chat_id: 80"],
+		plan_references: [],
+	},
+};
+
+test("chunk manifest preserves upstream turn ids", () => {
+	const built = buildConversationMessages({
+		entry_id: "conv-1",
+		scale: "128k",
+		chat: [
+			{ speaker: "user", text: "Berlin", source_id: "41" },
+			{ speaker: "assistant", text: "Noted", source_id: "42" },
+		],
+		probing_questions: [question],
+	});
+
+	assert.equal(built.messages.length, 1);
+	assert.deepEqual(built.messages[0]?.metadata?.sourceTurnIds, ["41", "42"]);
+	assert.deepEqual(built.chunks[0]?.source_turn_ids, ["41", "42"]);
+	assert.equal(built.chunks[0]?.content_sha256.length, 64);
+});
+
+test("retrieval diagnostics map ranked hits back to required source turns", () => {
+	const chunks = new Map([
+		[
+			"chunk-1",
+			{
+				schema_version: BEAM_TRACE_SCHEMA_VERSION,
+				entry_id: "conv-1",
+				scale: "128k" as const,
+				message_id: "chunk-1",
+				chunk_index: 0,
+				ingest_batch_index: 0,
+				turn_start: 0,
+				turn_end: 19,
+				source_turn_ids: ["41"],
+				content_sha256: "hash",
+				content_characters: 7,
+				first_timestamp: null,
+				last_timestamp: null,
+				ingest_status: "completed" as const,
+				ingest_latency_ms: 10,
+				ingest_warnings: [],
+			},
+		],
+		[
+			"chunk-3",
+			{
+				schema_version: BEAM_TRACE_SCHEMA_VERSION,
+				entry_id: "conv-1",
+				scale: "128k" as const,
+				message_id: "chunk-3",
+				chunk_index: 2,
+				ingest_batch_index: 0,
+				turn_start: 40,
+				turn_end: 59,
+				source_turn_ids: ["80"],
+				content_sha256: "hash",
+				content_characters: 7,
+				first_timestamp: null,
+				last_timestamp: null,
+				ingest_status: "completed" as const,
+				ingest_latency_ms: 10,
+				ingest_warnings: [],
+			},
+		],
+	]);
+	const retrieval = buildRetrievalTrace({
+		question,
+		response: {
+			query: question.question,
+			sources: ["memory"],
+			count: 3,
+			warnings: [],
+			results: [
+				{ id: "chunk-1", content: "Berlin", similarity: 0.91, metadata: {} },
+				{ id: "noise", content: "Paris", similarity: 0.82, metadata: {} },
+				{ id: "chunk-3", content: "Germany", similarity: 0.75, metadata: {} },
+			],
+		},
+		chunksByMessageId: chunks,
+		availableSourceTurnIds: ["41", "80"],
+		userId: "beam_conv-1",
+		topK: 8,
+		latencyMs: 12,
+	});
+
+	assert.equal(retrieval.source_recall_at_k, 1);
+	assert.equal(retrieval.all_required_sources_retrieved, true);
+	assert.equal(retrieval.first_relevant_rank, 1);
+	assert.equal(retrieval.mrr, 1);
+	assert.equal(retrieval.relevant_hit_precision, 2 / 3);
+	assert.deepEqual(retrieval.required_source_turn_ids, ["41", "80"]);
+	assert.deepEqual(retrieval.retrieved_source_turn_ids, ["41", "80"]);
+	assert.deepEqual(retrieval.missing_source_turn_ids, []);
+	assert.equal(retrieval.hit_at_k, 1);
+	assert.equal(retrieval.hits[0]?.content, "Berlin");
+	assert.deepEqual(retrieval.hits[0]?.matched_source_turn_ids, ["41"]);
+	assert.deepEqual(buildAnswerAttribution("See Memory excerpt 3 and [1].", retrieval), {
+		cited_hit_ids: ["chunk-1", "chunk-3"],
+		cited_relevant_hit_ids: ["chunk-1", "chunk-3"],
+		attribution_status: "supported",
+	});
+});
+
+test("diagnostics classify failures without changing nugget scoring", () => {
+	const scores = [1, 0.5, 0];
+	const headline = summarizeNuggetScores(scores);
+	assert.deepEqual(headline, {
+		nugget_mean: 0.5,
+		nugget_pass: true,
+	});
+	const scoredPrediction = {
+		status: "completed",
+		failure_stage: "none",
+		nugget_scores: [...scores],
+		nugget_mean: headline.nugget_mean,
+		nugget_pass: headline.nugget_pass,
+		trace: { retrieval: null, answerer: null, judge: null },
+	} as Prediction;
+	calculateDiagnosticSummary([scoredPrediction]);
+	assert.deepEqual(
+		{
+			scores: scoredPrediction.nugget_scores,
+			mean: scoredPrediction.nugget_mean,
+			pass: scoredPrediction.nugget_pass,
+		},
+		{ scores, mean: 0.5, pass: true },
+	);
+	assert.equal(
+		deriveFailureStage({
+			question,
+			retrieval: {
+				status: "completed",
+				query: question.question,
+				user_id: "beam_conv-1",
+				top_k: 8,
+				strategy: "daemon-default",
+				latency_ms: 1,
+				response_query: question.question,
+				response_sources: ["memory"],
+				response_count: 0,
+				response_warnings: [],
+				response_reasoning: null,
+				hits: [],
+				retrieval_applicable: true,
+				required_source_turn_ids: ["41", "80"],
+				available_source_turn_ids: ["41", "80"],
+				missing_source_turn_ids: [],
+				retrieved_source_turn_ids: ["41"],
+				missed_source_turn_ids: ["80"],
+				dataset_source_coverage: 1,
+				source_recall_at_k: 0.5,
+				retrievable_source_recall_at_k: 0.5,
+				all_required_sources_retrieved: false,
+				hit_at_k: 1,
+				first_relevant_rank: 1,
+				mrr: 1,
+				precision_at_k: 0.125,
+				relevant_hit_precision: 1,
+			},
+			nuggetPass: false,
+		}),
+		"retrieval_partial",
+	);
+	assert.equal(
+		deriveFailureStage({
+			question,
+			retrieval: {
+				status: "completed",
+				missing_source_turn_ids: [],
+				available_source_turn_ids: ["41", "80"],
+				source_recall_at_k: 0.5,
+			} as unknown as BeamRetrievalTrace,
+			nuggetPass: true,
+		}),
+		"none",
+	);
+
+	const minimal = {
+		status: "execution_error",
+		failure_stage: "judge_error",
+		trace: { retrieval: null, answerer: null, judge: null },
+	} as Prediction;
+	assert.deepEqual(calculateDiagnosticSummary([minimal]), {
+		completed: 0,
+		execution_errors: 1,
+		failure_stages: { judge_error: 1 },
+		retrieval_applicable_questions: 0,
+		mean_source_recall_at_k: null,
+		mean_retrievable_source_recall_at_k: null,
+		mean_dataset_source_coverage: null,
+		hit_at_k_rate: null,
+		mean_precision_at_k: null,
+		mean_reciprocal_rank: null,
+		all_required_sources_retrieved_rate: null,
+	});
+});
+
+test("search client preserves daemon diagnostics and per-hit signals", async () => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		new Response(
+			JSON.stringify({
+				query: "rewritten query",
+				sources: ["memory"],
+				count: 1,
+				warnings: [{ code: "fixture_warning" }],
+				reasoning: { strategy: "none" },
+				results: [
+					{
+						id: "chunk-1",
+						content: "Berlin",
+						similarity: 0.9,
+						metadata: { sourceTurnIds: ["41"] },
+						signals: { semantic: 0.9, rrf: 0.03 },
+					},
+				],
+			}),
+			{ status: 200, headers: { "Content-Type": "application/json" } },
+		)) as typeof fetch;
+	try {
+		const response = await searchMemory("Which city?", 8, "http://fixture", "beam_conv-1");
+		assert.equal(response.query, "rewritten query");
+		assert.deepEqual(response.warnings, [{ code: "fixture_warning" }]);
+		assert.deepEqual(response.reasoning, { strategy: "none" });
+		assert.deepEqual(response.results[0]?.signals, { semantic: 0.9, rrf: 0.03 });
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("ingest client aggregates batch counts and daemon warnings", async () => {
+	const originalFetch = globalThis.fetch;
+	let batch = 0;
+	globalThis.fetch = (async (_url, init) => {
+		batch++;
+		const body = JSON.parse(String(init?.body)) as { messages: unknown[] };
+		return new Response(
+			JSON.stringify({ count: body.messages.length, warnings: [{ code: `batch_${batch}` }] }),
+			{ status: 200, headers: { "Content-Type": "application/json" } },
+		);
+	}) as typeof fetch;
+	try {
+		const messages = Array.from({ length: 26 }, (_, index) => ({
+			messageId: `message-${index}`,
+			userId: "benchmark_user",
+			platform: "benchmark",
+			botId: "beam",
+			timestamp: index,
+			content: `message ${index}`,
+			createdAt: index,
+		}));
+		const result = await ingestMessages(messages, "http://fixture", "beam_conv-1");
+		assert.equal(result.inserted, 26);
+		assert.deepEqual(result.warnings, [{ code: "batch_1" }, { code: "batch_2" }]);
+		assert.deepEqual(
+			result.batches.map((item) => ({
+				index: item.batch_index,
+				status: item.status,
+				inserted: item.inserted,
+			})),
+			[
+				{ index: 0, status: "completed", inserted: 25 },
+				{ index: 1, status: "completed", inserted: 1 },
+			],
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("ingest diagnostics identify the failed batch and preserve completed batches", async () => {
+	const originalFetch = globalThis.fetch;
+	let batch = 0;
+	globalThis.fetch = (async (_url, init) => {
+		batch++;
+		if (batch === 2) return new Response("fixture failure", { status: 503 });
+		const body = JSON.parse(String(init?.body)) as { messages: unknown[] };
+		return new Response(JSON.stringify({ count: body.messages.length, warnings: [] }), { status: 200 });
+	}) as typeof fetch;
+	try {
+		const messages = Array.from({ length: 26 }, (_, index) => ({
+			messageId: `message-${index}`,
+			userId: "benchmark_user",
+			platform: "benchmark",
+			botId: "beam",
+			timestamp: index,
+			content: `message ${index}`,
+			createdAt: index,
+		}));
+		await assert.rejects(ingestMessages(messages, "http://fixture", "beam_conv-1"), (error: unknown) => {
+			assert.ok(error instanceof IngestMessagesError);
+			assert.equal(error.result.inserted, 25);
+			assert.deepEqual(
+				error.result.batches.map((item) => item.status),
+				["completed", "execution_error"],
+			);
+			assert.deepEqual(error.result.batches[1]?.message_ids, ["message-25"]);
+			return true;
+		});
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});

--- a/benchmark/beam/src/diagnostics.ts
+++ b/benchmark/beam/src/diagnostics.ts
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto";
+
+import type { MemorySearchResponse } from "./opencontext-client";
+import type {
+	BeamAnswerTrace,
+	BeamChunkTrace,
+	BeamFailureStage,
+	BeamProbingQuestion,
+	BeamRetrievalTrace,
+	Prediction,
+} from "./types";
+
+export function sha256Text(text: string): string {
+	return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+export function buildRetrievalTrace(input: {
+	question: BeamProbingQuestion;
+	response: MemorySearchResponse;
+	chunksByMessageId: ReadonlyMap<string, BeamChunkTrace>;
+	availableSourceTurnIds: readonly string[];
+	userId: string;
+	topK: number;
+	latencyMs: number;
+}): BeamRetrievalTrace {
+	const requiredIds = unique(input.question.source.source_chat_ids);
+	const requiredSet = new Set(requiredIds);
+	const availableSet = new Set(input.availableSourceTurnIds);
+	const availableRequiredIds = requiredIds.filter((id) => availableSet.has(id));
+	const missingSourceIds = requiredIds.filter((id) => !availableSet.has(id));
+	const retrievedRequiredIds = new Set<string>();
+
+	const hits = input.response.results.map((hit, index) => {
+		const localChunk = input.chunksByMessageId.get(hit.id);
+		const sourceTurnIds = unique([
+			...stringArray(hit.metadata.sourceTurnIds),
+			...stringArray(hit.metadata.source_turn_ids),
+			...(localChunk?.source_turn_ids ?? []),
+		]);
+		for (const sourceId of sourceTurnIds) {
+			if (requiredSet.has(sourceId)) retrievedRequiredIds.add(sourceId);
+		}
+		const matchedSourceTurnIds = sourceTurnIds.filter((id) => requiredSet.has(id));
+		const relevant = requiredIds.length === 0 ? null : matchedSourceTurnIds.length > 0;
+		return {
+			rank: index + 1,
+			id: hit.id,
+			similarity: hit.similarity,
+			signals: hit.signals ?? null,
+			metadata: hit.metadata,
+			content_sha256: sha256Text(hit.content),
+			content_characters: hit.content.length,
+			content_excerpt: hit.content.replace(/\s+/g, " ").trim().slice(0, 240),
+			content: hit.content,
+			source_turn_ids: sourceTurnIds,
+			matched_source_turn_ids: matchedSourceTurnIds,
+			relevant,
+		};
+	});
+
+	const relevantHits = hits.filter((hit) => hit.relevant === true);
+	const firstRelevantRank = relevantHits[0]?.rank ?? null;
+	const retrievalApplicable = requiredIds.length > 0;
+	const retrievedSourceIds = requiredIds.filter((id) => retrievedRequiredIds.has(id));
+	const missedSourceIds = requiredIds.filter((id) => !retrievedRequiredIds.has(id));
+
+	return {
+		status: "completed",
+		query: input.question.question,
+		user_id: input.userId,
+		top_k: input.topK,
+		strategy: "daemon-default",
+		latency_ms: input.latencyMs,
+		response_query: input.response.query,
+		response_sources: input.response.sources,
+		response_count: input.response.count,
+		response_warnings: input.response.warnings,
+		response_reasoning: input.response.reasoning ?? null,
+		hits,
+		retrieval_applicable: retrievalApplicable,
+		required_source_turn_ids: requiredIds,
+		available_source_turn_ids: availableRequiredIds,
+		missing_source_turn_ids: missingSourceIds,
+		retrieved_source_turn_ids: retrievedSourceIds,
+		missed_source_turn_ids: missedSourceIds,
+		dataset_source_coverage: retrievalApplicable ? availableRequiredIds.length / requiredIds.length : null,
+		source_recall_at_k: retrievalApplicable ? retrievedRequiredIds.size / requiredIds.length : null,
+		retrievable_source_recall_at_k:
+			availableRequiredIds.length > 0 ? retrievedRequiredIds.size / availableRequiredIds.length : null,
+		all_required_sources_retrieved: retrievalApplicable
+			? retrievedRequiredIds.size === requiredIds.length
+			: null,
+		first_relevant_rank: firstRelevantRank,
+		hit_at_k: retrievalApplicable ? (firstRelevantRank === null ? 0 : 1) : null,
+		mrr: firstRelevantRank === null ? (retrievalApplicable ? 0 : null) : 1 / firstRelevantRank,
+		precision_at_k: retrievalApplicable ? relevantHits.length / input.topK : null,
+		relevant_hit_precision: retrievalApplicable
+			? hits.length === 0
+				? 0
+				: relevantHits.length / hits.length
+			: null,
+	};
+}
+
+export function buildAnswerAttribution(
+	answer: string,
+	retrieval: BeamRetrievalTrace,
+): Pick<BeamAnswerTrace, "cited_hit_ids" | "cited_relevant_hit_ids" | "attribution_status"> {
+	const citedRanks = new Set<number>();
+	for (const pattern of [/\b(?:memory\s+)?excerpt\s+#?(\d+)\b/gi, /\[(\d+)\]/g]) {
+		for (const match of answer.matchAll(pattern)) {
+			const rank = Number.parseInt(match[1] ?? "", 10);
+			if (Number.isInteger(rank) && rank >= 1 && rank <= retrieval.hits.length) citedRanks.add(rank);
+		}
+	}
+	const citedHits = retrieval.hits.filter((hit) => citedRanks.has(hit.rank));
+	const citedRelevantHits = citedHits.filter((hit) => hit.relevant === true);
+	let attributionStatus: BeamAnswerTrace["attribution_status"];
+	if (!retrieval.retrieval_applicable) attributionStatus = "not_applicable";
+	else if (citedHits.length === 0) attributionStatus = "uncited";
+	else if (citedRelevantHits.length > 0) attributionStatus = "supported";
+	else attributionStatus = "unsupported";
+	return {
+		cited_hit_ids: citedHits.map((hit) => hit.id),
+		cited_relevant_hit_ids: citedRelevantHits.map((hit) => hit.id),
+		attribution_status: attributionStatus,
+	};
+}
+
+export function deriveFailureStage(input: {
+	question: BeamProbingQuestion;
+	retrieval: BeamRetrievalTrace | null;
+	nuggetPass: boolean;
+	executionStage?: "ingest" | "retrieval" | "answerer" | "judge" | "provider";
+}): BeamFailureStage {
+	if (input.executionStage === "ingest") return "ingest_or_index_error";
+	if (input.executionStage === "retrieval") return "retrieval_error";
+	if (input.executionStage === "answerer") return "answerer_error";
+	if (input.executionStage === "judge") return "judge_error";
+	if (input.executionStage === "provider") return "provider_error";
+	if (input.nuggetPass) return "none";
+	if (input.question.category === "abstention" && input.question.source.source_chat_ids.length === 0) {
+		return input.nuggetPass ? "none" : "context_present_answer_failed";
+	}
+	if (input.question.source.source_chat_ids.length === 0) return "dataset_reference_missing";
+	if ((input.retrieval?.missing_source_turn_ids.length ?? 0) > 0) {
+		return input.retrieval?.available_source_turn_ids.length === 0
+			? "dataset_reference_missing"
+			: "dataset_reference_partial";
+	}
+	if (!input.retrieval || input.retrieval.source_recall_at_k === 0) return "retrieval_miss";
+	if ((input.retrieval.source_recall_at_k ?? 0) < 1) return "retrieval_partial";
+	return "context_present_answer_failed";
+}
+
+export function calculateDiagnosticSummary(predictions: Prediction[]): Record<string, unknown> {
+	const failureStages: Record<string, number> = {};
+	const retrievalRecalls: number[] = [];
+	const reciprocalRanks: number[] = [];
+	const retrievableRecalls: number[] = [];
+	const sourceCoverages: number[] = [];
+	const hitAtK: number[] = [];
+	const precisionAtK: number[] = [];
+	let completed = 0;
+	let executionErrors = 0;
+	let retrievalApplicable = 0;
+	let allSourcesRetrieved = 0;
+
+	for (const prediction of predictions) {
+		failureStages[prediction.failure_stage] = (failureStages[prediction.failure_stage] ?? 0) + 1;
+		if (prediction.status === "completed") completed++;
+		else executionErrors++;
+		const retrieval = prediction.trace.retrieval;
+		if (retrieval?.retrieval_applicable) {
+			retrievalApplicable++;
+			if (retrieval.all_required_sources_retrieved) allSourcesRetrieved++;
+			if (retrieval.source_recall_at_k !== null) retrievalRecalls.push(retrieval.source_recall_at_k);
+			if (retrieval.retrievable_source_recall_at_k !== null)
+				retrievableRecalls.push(retrieval.retrievable_source_recall_at_k);
+			if (retrieval.dataset_source_coverage !== null) sourceCoverages.push(retrieval.dataset_source_coverage);
+			if (retrieval.hit_at_k !== null) hitAtK.push(retrieval.hit_at_k);
+			if (retrieval.precision_at_k !== null) precisionAtK.push(retrieval.precision_at_k);
+			if (retrieval.mrr !== null) reciprocalRanks.push(retrieval.mrr);
+		}
+	}
+
+	const mean = (values: number[]): number | null =>
+		values.length === 0 ? null : values.reduce((sum, value) => sum + value, 0) / values.length;
+	return {
+		completed,
+		execution_errors: executionErrors,
+		failure_stages: failureStages,
+		retrieval_applicable_questions: retrievalApplicable,
+		mean_source_recall_at_k: mean(retrievalRecalls),
+		mean_retrievable_source_recall_at_k: mean(retrievableRecalls),
+		mean_dataset_source_coverage: mean(sourceCoverages),
+		hit_at_k_rate: mean(hitAtK),
+		mean_precision_at_k: mean(precisionAtK),
+		mean_reciprocal_rank: mean(reciprocalRanks),
+		all_required_sources_retrieved_rate:
+			retrievalApplicable === 0 ? null : allSourcesRetrieved / retrievalApplicable,
+	};
+}

--- a/benchmark/beam/src/evaluator.ts
+++ b/benchmark/beam/src/evaluator.ts
@@ -19,23 +19,40 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { sumTokenUsage, unavailableTokenUsage, zeroTokenUsage } from "../../run-support";
+import { sumTokenUsage, unavailableTokenUsage } from "../../run-support";
+import { buildAnswerAttribution, buildRetrievalTrace, deriveFailureStage, sha256Text } from "./diagnostics";
 import {
 	type NuggetJudgeResult,
 	evaluateNuggetJudge,
+	getJudgeModelIdentity,
 	looksLikeAbstention,
 	summarizeNuggetScores,
 } from "./metrics";
 import {
 	type BenchRawMessage,
+	INGEST_BATCH_SIZE,
+	type IngestBatchTrace,
+	IngestMessagesError,
 	type MemorySearchHit,
+	type MemorySearchResponse,
 	checkOpencontextHealth,
 	generateAnswer,
+	getAnswererModelIdentity,
 	getOpencontextBaseUrl,
 	ingestMessages,
 	searchMemory,
 } from "./opencontext-client";
-import type { BeamConversation, BeamProbingQuestion, BeamTurn, Prediction } from "./types";
+import {
+	BEAM_TRACE_SCHEMA_VERSION,
+	type BeamAnswerTrace,
+	type BeamChunkTrace,
+	type BeamConversation,
+	type BeamJudgeTrace,
+	type BeamProbingQuestion,
+	type BeamRetrievalTrace,
+	type BeamTurn,
+	type Prediction,
+} from "./types";
 
 /**
  * How many turns go into a single ingested memory message.
@@ -94,8 +111,12 @@ function buildChunkText(
 /**
  * Convert a BEAM conversation into raw messages for the memory store.
  */
-function buildConversationMessages(conv: BeamConversation): BenchRawMessage[] {
+export function buildConversationMessages(conv: BeamConversation): {
+	messages: BenchRawMessage[];
+	chunks: BeamChunkTrace[];
+} {
 	const messages: BenchRawMessage[] = [];
+	const chunks: BeamChunkTrace[] = [];
 	const now = Date.now();
 
 	let chunkIndex = 0;
@@ -107,9 +128,13 @@ function buildConversationMessages(conv: BeamConversation): BenchRawMessage[] {
 
 		const firstTs = slice[0]?.timestamp;
 		const lastTs = slice[slice.length - 1]?.timestamp;
+		const sourceTurnIds = slice
+			.map((turn) => turn.source_id)
+			.filter((id): id is string => typeof id === "string");
+		const messageId = `beam_${conv.entry_id}__chunk_${chunkIndex}`;
 
 		messages.push({
-			messageId: `beam_${conv.entry_id}__chunk_${chunkIndex}`,
+			messageId,
 			userId: "benchmark_user",
 			platform: "benchmark",
 			botId: "beam",
@@ -123,13 +148,57 @@ function buildConversationMessages(conv: BeamConversation): BenchRawMessage[] {
 				contentType: "beam_chunk",
 				turnStart: startTurn,
 				turnEnd: endTurn,
+				sourceTurnIds,
 			},
+		});
+		chunks.push({
+			schema_version: BEAM_TRACE_SCHEMA_VERSION,
+			entry_id: conv.entry_id,
+			scale: conv.scale,
+			message_id: messageId,
+			chunk_index: chunkIndex,
+			ingest_batch_index: Math.floor(chunkIndex / INGEST_BATCH_SIZE),
+			turn_start: startTurn,
+			turn_end: endTurn,
+			source_turn_ids: sourceTurnIds,
+			content_sha256: sha256Text(text),
+			content_characters: text.length,
+			first_timestamp: firstTs ?? null,
+			last_timestamp: lastTs ?? null,
+			ingest_status: "pending",
+			ingest_latency_ms: null,
+			ingest_warnings: [],
 		});
 
 		chunkIndex++;
 	}
 
-	return messages;
+	return { messages, chunks };
+}
+
+export function fingerprintConversation(conv: BeamConversation): string {
+	return sha256Text(JSON.stringify({ entry_id: conv.entry_id, scale: conv.scale, chat: conv.chat }));
+}
+
+export function fingerprintQuestion(question: BeamProbingQuestion): string {
+	return sha256Text(JSON.stringify(question));
+}
+
+function applyIngestBatchTraces(chunks: BeamChunkTrace[], batches: IngestBatchTrace[]): void {
+	const byMessageId = new Map(
+		batches.flatMap((batch) => batch.message_ids.map((messageId) => [messageId, batch] as const)),
+	);
+	for (const chunk of chunks) {
+		const batch = byMessageId.get(chunk.message_id);
+		if (!batch) {
+			chunk.ingest_status = "not_attempted";
+			continue;
+		}
+		chunk.ingest_status = batch.status;
+		chunk.ingest_latency_ms = batch.latency_ms;
+		chunk.ingest_warnings = batch.warnings;
+		if (batch.error) chunk.error = batch.error;
+	}
 }
 
 function buildAnswerPrompt(
@@ -206,6 +275,8 @@ export class BeamEvaluator {
 	private quickLimit?: number;
 	private checkpointDir: string;
 	private resume: boolean;
+	private chunkTraces = new Map<string, BeamChunkTrace>();
+	private conversationFingerprints = new Map<string, string>();
 
 	constructor(baseUrl?: string, quickLimit?: number, resume = true) {
 		this.baseUrl = baseUrl ?? getOpencontextBaseUrl();
@@ -237,15 +308,87 @@ export class BeamEvaluator {
 		}
 	}
 
+	getChunkTraces(): BeamChunkTrace[] {
+		return [...this.chunkTraces.values()];
+	}
+
+	createExecutionErrorPrediction(
+		conv: BeamConversation,
+		question: BeamProbingQuestion,
+		error: unknown,
+		stage: "ingest" | "retrieval" | "answerer" | "judge" | "provider",
+		attempt = 1,
+		trace: { retrieval?: BeamRetrievalTrace | null; answerer?: BeamAnswerTrace | null } = {},
+	): Prediction {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		return {
+			trace_schema_version: BEAM_TRACE_SCHEMA_VERSION,
+			entry_id: conv.entry_id,
+			conversation_sha256: this.conversationFingerprints.get(conv.entry_id) ?? fingerprintConversation(conv),
+			question_sha256: fingerprintQuestion(question),
+			status: "execution_error",
+			attempt,
+			execution_error: { stage, message: errorMessage },
+			token_usage: unavailableTokenUsage(),
+			answerer_model: getAnswererModelIdentity(),
+			judge_model: getJudgeModelIdentity(),
+			question_id: question.question_id,
+			question: question.question,
+			gold_answer: question.gold_answer ?? null,
+			source: question.source,
+			response: `Error: ${errorMessage}`,
+			prediction: `Error: ${errorMessage}`,
+			atoms: question.atoms,
+			category: question.category,
+			scale: conv.scale,
+			nugget_scores: question.atoms.map(() => 0),
+			nugget_mean: 0,
+			nugget_pass: false,
+			judge_reasoning: `agent failure: ${errorMessage}`,
+			trace: {
+				retrieval: trace.retrieval ?? null,
+				answerer: trace.answerer ?? null,
+				judge: null,
+			},
+			failure_stage: deriveFailureStage({
+				question,
+				retrieval: trace.retrieval ?? null,
+				nuggetPass: false,
+				executionStage: stage,
+			}),
+			abstained: false,
+		};
+	}
+
 	/**
 	 * Ingest a BEAM conversation into the OpenContext memory store.
 	 * Returns the number of ingested chunk messages.
 	 */
 	async loadConversation(conv: BeamConversation): Promise<number> {
-		const messages = buildConversationMessages(conv);
-		const inserted = await ingestMessages(messages, this.baseUrl, beamUserId(conv));
-		console.log(`[BEAM] Ingested ${inserted} chunk messages for ${conv.entry_id} → ${this.baseUrl}`);
-		return messages.length;
+		const { messages, chunks } = buildConversationMessages(conv);
+		this.conversationFingerprints.set(conv.entry_id, fingerprintConversation(conv));
+		for (const chunk of chunks) this.chunkTraces.set(chunk.message_id, chunk);
+		const startedAt = performance.now();
+		try {
+			const ingestResult = await ingestMessages(messages, this.baseUrl, beamUserId(conv));
+			applyIngestBatchTraces(chunks, ingestResult.batches);
+			console.log(
+				`[BEAM] Ingested ${ingestResult.inserted} chunk messages for ${conv.entry_id} → ${this.baseUrl}`,
+			);
+			return messages.length;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (error instanceof IngestMessagesError) applyIngestBatchTraces(chunks, error.result.batches);
+			else {
+				const latencyMs = Math.round(performance.now() - startedAt);
+				for (const chunk of chunks) {
+					chunk.ingest_status = "execution_error";
+					chunk.ingest_latency_ms = latencyMs;
+					chunk.error = message;
+				}
+			}
+			throw error;
+		}
 	}
 
 	/**
@@ -256,11 +399,25 @@ export class BeamEvaluator {
 		question: BeamProbingQuestion,
 		_chunkCount: number,
 	): Promise<Prediction> {
-		// Resume support — but re-judge on resume so a stale judge doesn't
-		// poison the run if we re-run with a new judge model.
+		const answererModel = getAnswererModelIdentity();
+		const judgeModel = getJudgeModelIdentity();
+		const conversationSha256 =
+			this.conversationFingerprints.get(conv.entry_id) ?? fingerprintConversation(conv);
+		const questionSha256 = fingerprintQuestion(question);
+
+		// Reuse only completed results produced by the currently configured models.
 		const checkpoint = await this.loadCheckpoint(question.question_id);
+		const checkpointMatchesContext =
+			checkpoint?.trace_schema_version === BEAM_TRACE_SCHEMA_VERSION &&
+			checkpoint.entry_id === conv.entry_id &&
+			checkpoint.conversation_sha256 === conversationSha256 &&
+			checkpoint.question_sha256 === questionSha256 &&
+			checkpoint.answerer_model === answererModel &&
+			checkpoint.judge_model === judgeModel;
 		if (
 			checkpoint?.response &&
+			checkpointMatchesContext &&
+			checkpoint.status === "completed" &&
 			!checkpoint.response.startsWith("Error:") &&
 			checkpoint.nugget_scores.length === question.atoms.length &&
 			!checkpoint.judge_reasoning.startsWith("judge failure")
@@ -268,39 +425,185 @@ export class BeamEvaluator {
 			console.log(`[BEAM] Resuming from checkpoint for ${question.question_id}`);
 			return checkpoint;
 		}
+		if (
+			checkpoint &&
+			(checkpoint.answerer_model !== answererModel || checkpoint.judge_model !== judgeModel)
+		) {
+			console.log(`[BEAM] Ignoring checkpoint for ${question.question_id}: model configuration changed`);
+		} else if (checkpoint && checkpoint.trace_schema_version !== BEAM_TRACE_SCHEMA_VERSION) {
+			console.log(`[BEAM] Ignoring legacy checkpoint for ${question.question_id}: diagnostic trace missing`);
+		} else if (
+			checkpoint &&
+			(checkpoint.entry_id !== conv.entry_id ||
+				checkpoint.conversation_sha256 !== conversationSha256 ||
+				checkpoint.question_sha256 !== questionSha256)
+		) {
+			console.log(`[BEAM] Ignoring checkpoint for ${question.question_id}: conversation data changed`);
+		} else if (checkpoint?.status === "execution_error") {
+			console.log(`[BEAM] Retrying execution error for ${question.question_id}`);
+		}
 
+		const attempt =
+			checkpointMatchesContext && checkpoint.status === "execution_error" ? (checkpoint.attempt ?? 0) + 1 : 1;
 		let answerUsage = unavailableTokenUsage();
 		let judgeUsage = unavailableTokenUsage();
+		let retrievalTrace: BeamRetrievalTrace | null = null;
+		let answerTrace: BeamAnswerTrace | null = null;
+		let executionStage: "retrieval" | "answerer" | "judge" = "retrieval";
 		try {
-			const hits = await searchMemory(question.question, RETRIEVAL_LIMIT, this.baseUrl, beamUserId(conv));
+			const searchStartedAt = performance.now();
+			let searchResponse: MemorySearchResponse;
+			try {
+				searchResponse = await searchMemory(
+					question.question,
+					RETRIEVAL_LIMIT,
+					this.baseUrl,
+					beamUserId(conv),
+				);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				const availableSet = new Set(
+					conv.chat.map((turn) => turn.source_id).filter((id): id is string => typeof id === "string"),
+				);
+				const requiredIds = [...new Set(question.source.source_chat_ids)];
+				const availableIds = requiredIds.filter((id) => availableSet.has(id));
+				const missingIds = requiredIds.filter((id) => !availableSet.has(id));
+				retrievalTrace = {
+					status: "execution_error",
+					query: question.question,
+					user_id: beamUserId(conv),
+					top_k: RETRIEVAL_LIMIT,
+					strategy: "daemon-default",
+					latency_ms: Math.round(performance.now() - searchStartedAt),
+					response_query: question.question,
+					response_sources: [],
+					response_count: 0,
+					response_warnings: [],
+					response_reasoning: null,
+					hits: [],
+					retrieval_applicable: question.source.source_chat_ids.length > 0,
+					required_source_turn_ids: requiredIds,
+					available_source_turn_ids: availableIds,
+					missing_source_turn_ids: missingIds,
+					retrieved_source_turn_ids: [],
+					missed_source_turn_ids: requiredIds,
+					dataset_source_coverage: requiredIds.length > 0 ? availableIds.length / requiredIds.length : null,
+					source_recall_at_k: null,
+					retrievable_source_recall_at_k: null,
+					all_required_sources_retrieved: null,
+					hit_at_k: null,
+					first_relevant_rank: null,
+					mrr: null,
+					precision_at_k: null,
+					relevant_hit_precision: null,
+					error: message,
+				};
+				throw error;
+			}
+			retrievalTrace = buildRetrievalTrace({
+				question,
+				response: searchResponse,
+				chunksByMessageId: this.chunkTraces,
+				availableSourceTurnIds: conv.chat
+					.map((turn) => turn.source_id)
+					.filter((id): id is string => typeof id === "string"),
+				userId: beamUserId(conv),
+				topK: RETRIEVAL_LIMIT,
+				latencyMs: Math.round(performance.now() - searchStartedAt),
+			});
+			const hits = searchResponse.results;
 			const prompt = buildAnswerPrompt(conv, question, hits);
-			const answerResult = await generateAnswer(prompt);
-			answerUsage = answerResult.token_usage;
-			const response = answerResult.text;
-			if (!response.trim()) throw new Error("answerer returned an empty response");
+			executionStage = "answerer";
+			const answerStartedAt = performance.now();
+			let response: string;
+			try {
+				const answerResult = await generateAnswer(prompt);
+				answerUsage = answerResult.token_usage;
+				response = answerResult.text;
+				if (!response.trim()) throw new Error("answerer returned an empty response");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				answerTrace = {
+					model: answererModel,
+					status: "execution_error",
+					attempt: 1,
+					latency_ms: Math.round(performance.now() - answerStartedAt),
+					prompt_version: "beam-answer-v1",
+					prompt_sha256: sha256Text(prompt),
+					prompt_characters: prompt.length,
+					system_prompt: null,
+					prompt,
+					token_usage: answerUsage,
+					included_hit_ids: hits.map((hit) => hit.id),
+					cited_hit_ids: [],
+					cited_relevant_hit_ids: [],
+					attribution_status: retrievalTrace.retrieval_applicable ? "uncited" : "not_applicable",
+					error: message,
+				};
+				throw error;
+			}
+			const attribution = buildAnswerAttribution(response, retrievalTrace);
+			answerTrace = {
+				model: answererModel,
+				status: "completed",
+				attempt: 1,
+				latency_ms: Math.round(performance.now() - answerStartedAt),
+				prompt_version: "beam-answer-v1",
+				prompt_sha256: sha256Text(prompt),
+				prompt_characters: prompt.length,
+				system_prompt: null,
+				prompt,
+				token_usage: answerUsage,
+				included_hit_ids: hits.map((hit) => hit.id),
+				...attribution,
+			};
 
 			const abstained = looksLikeAbstention(response);
 
-			let judgeResult: NuggetJudgeResult;
-			if (question.atoms.length === 0) {
-				console.warn(`[BEAM] Question ${question.question_id} has no atoms — using empty judge result`);
-				judgeResult = { scores: [], reasoning: "no atoms", token_usage: zeroTokenUsage() };
-			} else {
-				judgeResult = await evaluateNuggetJudge(
-					question.question,
-					question.category,
-					question.atoms,
-					response,
-				);
-			}
+			executionStage = "judge";
+			const judgeResult: NuggetJudgeResult = await evaluateNuggetJudge(
+				question.question,
+				question.category,
+				question.atoms,
+				response,
+			);
 			judgeUsage = judgeResult.token_usage;
+			const judgeTrace: BeamJudgeTrace = {
+				model: judgeModel,
+				status: judgeResult.status,
+				attempt: judgeResult.attempt,
+				latency_ms: judgeResult.latency_ms,
+				prompt_version: judgeResult.prompt_version,
+				prompt_sha256: judgeResult.prompt_sha256,
+				prompt_characters: judgeResult.prompt_characters,
+				system_prompt: judgeResult.system_prompt,
+				prompt: judgeResult.prompt,
+				token_usage: judgeResult.token_usage,
+				raw_response: judgeResult.raw_response,
+				parse_status: judgeResult.parse_status,
+				...(judgeResult.error ? { error: judgeResult.error } : {}),
+			};
 
 			const { nugget_mean, nugget_pass } = summarizeNuggetScores(judgeResult.scores);
+			const executionError = judgeResult.status === "execution_error";
 
 			const pred: Prediction = {
+				trace_schema_version: BEAM_TRACE_SCHEMA_VERSION,
+				entry_id: conv.entry_id,
+				conversation_sha256: conversationSha256,
+				question_sha256: questionSha256,
+				status: executionError ? "execution_error" : "completed",
+				attempt,
+				...(executionError
+					? { execution_error: { stage: "judge", message: judgeResult.error ?? "judge failure" } }
+					: {}),
 				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
+				answerer_model: answererModel,
+				judge_model: judgeModel,
 				question_id: question.question_id,
 				question: question.question,
+				gold_answer: question.gold_answer ?? null,
+				source: question.source,
 				response,
 				prediction: response,
 				atoms: question.atoms,
@@ -310,6 +613,13 @@ export class BeamEvaluator {
 				nugget_mean,
 				nugget_pass,
 				judge_reasoning: judgeResult.reasoning,
+				trace: { retrieval: retrievalTrace, answerer: answerTrace, judge: judgeTrace },
+				failure_stage: deriveFailureStage({
+					question,
+					retrieval: retrievalTrace,
+					nuggetPass: nugget_pass,
+					...(executionError ? { executionStage: "judge" as const } : {}),
+				}),
 				abstained,
 			};
 
@@ -323,23 +633,11 @@ export class BeamEvaluator {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			console.error(`Error evaluating question: ${errorMessage}`);
-
-			const emptyScores: number[] = question.atoms.map(() => 0);
-			const pred: Prediction = {
-				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
-				question_id: question.question_id,
-				question: question.question,
-				response: `Error: ${errorMessage}`,
-				prediction: `Error: ${errorMessage}`,
-				atoms: question.atoms,
-				category: question.category,
-				scale: conv.scale,
-				nugget_scores: emptyScores,
-				nugget_mean: 0,
-				nugget_pass: false,
-				judge_reasoning: `agent failure: ${errorMessage}`,
-				abstained: false,
-			};
+			const pred = this.createExecutionErrorPrediction(conv, question, error, executionStage, attempt, {
+				retrieval: retrievalTrace,
+				answerer: answerTrace,
+			});
+			pred.token_usage = sumTokenUsage([answerUsage, judgeUsage]);
 
 			await this.saveCheckpoint(question.question_id, pred);
 			return pred;

--- a/benchmark/beam/src/index.ts
+++ b/benchmark/beam/src/index.ts
@@ -22,9 +22,10 @@ import {
 	unavailableTokenUsage,
 	writeRunManifest,
 } from "../../run-support";
-import { expandBeamSamples, loadBeamDatasetFromJson } from "./dataset";
+import { expandBeamSamples, loadBeamDatasetWithMetadata } from "./dataset";
+import { calculateDiagnosticSummary } from "./diagnostics";
 import { BeamEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
-import { JUDGE_MODEL, type NuggetCategoryMetrics, calculateNuggetCategoryMetrics } from "./metrics";
+import { type NuggetCategoryMetrics, calculateNuggetCategoryMetrics, getJudgeModelIdentity } from "./metrics";
 import {
 	checkOpencontextHealth,
 	getAnswererModelIdentity,
@@ -36,7 +37,14 @@ import {
 	QUESTION_TYPES,
 	QUESTION_TYPE_NAMES,
 } from "./scorer";
-import type { BeamQuestionCategory, BeamScale, EvaluationResult, Prediction } from "./types";
+import {
+	BEAM_TRACE_SCHEMA_VERSION,
+	type BeamDatasetSource,
+	type BeamQuestionCategory,
+	type BeamScale,
+	type EvaluationResult,
+	type Prediction,
+} from "./types";
 
 interface CliArgs {
 	dataset: string;
@@ -187,10 +195,24 @@ Examples:
 `);
 }
 
-function printSummary(
-	predictionsByCategory: Record<BeamQuestionCategory, Prediction[]>,
-	args: CliArgs,
-): void {
+function diagnosticArtifactPath(outputPath: string, suffix: "trace" | "chunks"): string {
+	const resolved = resolve(outputPath);
+	const base = resolved.replace(/\.json$/i, "");
+	return `${base}.${suffix}.jsonl`;
+}
+
+async function writeJsonl(path: string, rows: unknown[]): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	const content = rows.map((row) => JSON.stringify(row)).join("\n");
+	await writeFile(path, content.length > 0 ? `${content}\n` : "", "utf-8");
+}
+
+function withoutDiagnosticTrace(prediction: Prediction): Omit<Prediction, "trace"> {
+	const { trace: _trace, ...result } = prediction;
+	return result;
+}
+
+function printSummary(predictionsByCategory: Record<BeamQuestionCategory, Prediction[]>): void {
 	console.log("=".repeat(80));
 	console.log("BEAM Evaluation Results Summary");
 	console.log("=".repeat(80));
@@ -254,7 +276,10 @@ async function main() {
 	const baseUrl = args.port ? `http://127.0.0.1:${args.port}` : getOpencontextBaseUrl();
 	const benchmarkDir = join(import.meta.dirname, "..");
 	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
-	let conversations: Awaited<ReturnType<typeof loadBeamDatasetFromJson>> = [];
+	const tracePath = args.output ? diagnosticArtifactPath(args.output, "trace") : undefined;
+	const chunksPath = args.output ? diagnosticArtifactPath(args.output, "chunks") : undefined;
+	let conversations: Awaited<ReturnType<typeof loadBeamDatasetWithMetadata>>["conversations"] = [];
+	let datasetSource: BeamDatasetSource | null = null;
 	let activeSamples: ReturnType<typeof expandBeamSamples> = [];
 	if (args.conversations !== undefined && (!Number.isInteger(args.conversations) || args.conversations < 1)) {
 		args.parameterErrors.push("--conversations must be a positive integer");
@@ -268,6 +293,9 @@ async function main() {
 	if (args.port !== undefined && (!Number.isInteger(args.port) || args.port < 1 || args.port > 65_535)) {
 		args.parameterErrors.push("--port must be an integer between 1 and 65535");
 	}
+	if (!process.env.OPENROUTER_JUDGE_MODEL?.trim()) {
+		args.parameterErrors.push("judge model missing: set OPENROUTER_JUDGE_MODEL");
+	}
 
 	await runPreflight({
 		datasetPath: args.dataset,
@@ -275,15 +303,19 @@ async function main() {
 			manifestPath,
 			join(benchmarkDir, "checkpoints", "beam", ".preflight"),
 			...(args.output ? [args.output] : []),
+			...(tracePath ? [tracePath] : []),
+			...(chunksPath ? [chunksPath] : []),
 		],
 		parameterErrors: args.parameterErrors,
 		validateDataset: async () => {
-			conversations = await loadBeamDatasetFromJson(args.dataset, {
+			const loaded = await loadBeamDatasetWithMetadata(args.dataset, {
 				conversations: args.conversations,
 				questionsPerConv: args.questionsPerConv,
 				types: args.types,
 				assertScale: args.scale,
 			});
+			conversations = loaded.conversations;
+			datasetSource = loaded.source;
 			activeSamples = expandBeamSamples(conversations);
 			if (args.quick) activeSamples = activeSamples.slice(0, 5);
 			if (conversations.length === 0 || activeSamples.length === 0) {
@@ -323,10 +355,9 @@ async function main() {
 
 	let lastConvEntryId = "";
 	let chunkCount = 0;
+	const evaluator = new BeamEvaluator(baseUrl, undefined, args.resume);
 
 	for (const sample of activeSamples) {
-		const evaluator = new BeamEvaluator(baseUrl, undefined, args.resume);
-
 		try {
 			// Re-load conversation if we moved to a new one
 			if (sample.conversation.entry_id !== lastConvEntryId) {
@@ -340,26 +371,17 @@ async function main() {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			console.error(`Error on ${sample.question.question_id}: ${errorMessage}`);
 
-			const failedPred: Prediction = {
-				token_usage: unavailableTokenUsage(),
-				question_id: sample.question.question_id,
-				question: sample.question.question,
-				response: `Error: ${errorMessage}`,
-				prediction: `Error: ${errorMessage}`,
-				atoms: sample.question.atoms,
-				category: sample.question.category,
-				scale: sample.conversation.scale,
-				nugget_scores: sample.question.atoms.map(() => 0),
-				nugget_mean: 0,
-				nugget_pass: false,
-				judge_reasoning: `agent failure: ${errorMessage}`,
-				abstained: false,
-			};
+			const failedPred = evaluator.createExecutionErrorPrediction(
+				sample.conversation,
+				sample.question,
+				error,
+				"ingest",
+			);
 			predictionsByCategory[failedPred.category].push(failedPred);
 		}
 	}
 
-	printSummary(predictionsByCategory, args);
+	printSummary(predictionsByCategory);
 
 	// Build per-entry EvaluationResult array for the JSON output
 	const perEntry = new Map<string, EvaluationResult>();
@@ -398,12 +420,13 @@ async function main() {
 
 	const predictions = Object.values(predictionsByCategory).flat();
 	const runTokenUsage = sumTokenUsage(predictions.map((prediction) => prediction.token_usage));
+	const diagnosticSummary = calculateDiagnosticSummary(predictions);
 	const finishedAt = new Date().toISOString();
 	const runManifest = await writeRunManifest(manifestPath, {
 		benchmark: "beam",
 		datasetPath: args.dataset,
 		answerer_model: getAnswererModelIdentity(),
-		judge_model: JUDGE_MODEL,
+		judge_model: getJudgeModelIdentity(),
 		retrieval: { strategy: "memory-search", top_k: RETRIEVAL_LIMIT },
 		resume: args.resume,
 		started_at: startedAt,
@@ -415,6 +438,10 @@ async function main() {
 			categories: args.types ?? null,
 			scale: args.scale ?? null,
 			quick: args.quick ?? false,
+			trace_schema_version: BEAM_TRACE_SCHEMA_VERSION,
+			dataset_source: datasetSource,
+			trace_artifact: tracePath ?? null,
+			chunks_artifact: chunksPath ?? null,
 		},
 	});
 	const output = {
@@ -425,6 +452,12 @@ async function main() {
 		categories_filter: args.types ?? null,
 		summary: calculateNuggetCategoryMetrics(predictions),
 		token_usage: runTokenUsage,
+		diagnostics: diagnosticSummary,
+		diagnostic_artifacts: {
+			trace_schema_version: BEAM_TRACE_SCHEMA_VERSION,
+			trace: tracePath ?? null,
+			chunks: chunksPath ?? null,
+		},
 		run_manifest: runManifest,
 		per_category: Object.fromEntries(
 			QUESTION_TYPES.filter((c) => predictionsByCategory[c].length > 0).map((c) => [
@@ -441,8 +474,46 @@ async function main() {
 
 	if (args.output) {
 		await mkdir(dirname(resolve(args.output)), { recursive: true });
-		await writeFile(args.output, JSON.stringify(output, null, 2), "utf-8");
+		const withoutEmbeddedTraces = {
+			...output,
+			per_entry: output.per_entry.map((entry) => ({
+				...entry,
+				predictions: entry.predictions.map(withoutDiagnosticTrace),
+			})),
+			predictions: output.predictions.map(withoutDiagnosticTrace),
+		};
+		await writeFile(args.output, JSON.stringify(withoutEmbeddedTraces, null, 2), "utf-8");
+		await writeJsonl(
+			tracePath as string,
+			predictions.map((prediction) => ({
+				schema_version: prediction.trace_schema_version,
+				question_id: prediction.question_id,
+				entry_id: prediction.entry_id,
+				conversation_sha256: prediction.conversation_sha256,
+				question_sha256: prediction.question_sha256,
+				question: prediction.question,
+				gold_answer: prediction.gold_answer,
+				atoms: prediction.atoms,
+				source: prediction.source,
+				status: prediction.status,
+				attempt: prediction.attempt,
+				execution_error: prediction.execution_error ?? null,
+				failure_stage: prediction.failure_stage,
+				answerer_model: prediction.answerer_model,
+				judge_model: prediction.judge_model,
+				response: prediction.response,
+				nugget_scores: prediction.nugget_scores,
+				nugget_mean: prediction.nugget_mean,
+				nugget_pass: prediction.nugget_pass,
+				judge_reasoning: prediction.judge_reasoning,
+				token_usage: prediction.token_usage,
+				trace: prediction.trace,
+			})),
+		);
+		await writeJsonl(chunksPath as string, evaluator.getChunkTraces());
 		console.log(`💾 Results saved to: ${args.output}`);
+		console.log(`🔎 Question traces saved to: ${tracePath}`);
+		console.log(`🧩 Chunk manifest saved to: ${chunksPath}`);
 	}
 	console.log(`🧾 Run manifest saved to: ${manifestPath}`);
 

--- a/benchmark/beam/src/metrics.ts
+++ b/benchmark/beam/src/metrics.ts
@@ -8,14 +8,19 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
-import { tokenUsage, type TokenUsage, unavailableTokenUsage, zeroTokenUsage } from "../../run-support";
+import { type TokenUsage, tokenUsage, unavailableTokenUsage, zeroTokenUsage } from "../../run-support";
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
 	apiKey: process.env.OPENROUTER_API_KEY,
 	name: "openrouter",
 });
+import { sha256Text } from "./diagnostics";
 import { BEAM_NUGGET_JUDGE_PROMPT } from "./prompts";
 import type { BeamQuestionCategory } from "./types";
+
+const MODEL_REQUEST_TIMEOUT_MS = 300_000;
+const JUDGE_SYSTEM_PROMPT =
+	"You are an impartial judge scoring answers to questions. Always respond with valid JSON.";
 
 /**
  * Calculate F1 score between prediction and ground truth.
@@ -115,9 +120,30 @@ export interface NuggetJudgeResult {
 	scores: number[];
 	reasoning: string;
 	token_usage: TokenUsage;
+	status: "completed" | "skipped" | "execution_error";
+	attempt: number;
+	latency_ms: number;
+	prompt_version: string;
+	prompt_sha256: string | null;
+	prompt_characters: number;
+	system_prompt: string | null;
+	prompt: string | null;
+	raw_response: string | null;
+	parse_status: "parsed" | "skipped" | "failed";
+	error?: string;
 }
 
-export const JUDGE_MODEL = "qwen/qwen3.7-max";
+export function getJudgeModel(): string {
+	const model = process.env.OPENROUTER_JUDGE_MODEL?.trim();
+	if (!model) {
+		throw new Error("Judge model missing: set OPENROUTER_JUDGE_MODEL");
+	}
+	return model;
+}
+
+export function getJudgeModelIdentity(): string {
+	return `openrouter:${getJudgeModel()}`;
+}
 
 /**
  * Normalize a raw judge score into the BEAM rubric's {0.0, 0.5, 1.0} set.
@@ -190,7 +216,21 @@ export async function evaluateNuggetJudge(
 	maxRetries = 3,
 ): Promise<NuggetJudgeResult> {
 	if (atoms.length === 0) {
-		return { scores: [], reasoning: "no atoms", token_usage: zeroTokenUsage() };
+		return {
+			scores: [],
+			reasoning: "no atoms",
+			token_usage: zeroTokenUsage(),
+			status: "skipped",
+			attempt: 0,
+			latency_ms: 0,
+			prompt_version: "beam-nugget-judge-v1",
+			prompt_sha256: null,
+			prompt_characters: 0,
+			system_prompt: null,
+			prompt: null,
+			raw_response: null,
+			parse_status: "skipped",
+		};
 	}
 
 	const prompt = BEAM_NUGGET_JUDGE_PROMPT.replace("{category}", category)
@@ -199,14 +239,18 @@ export async function evaluateNuggetJudge(
 		.replace("{answer}", generatedAnswer);
 
 	let lastError: Error | undefined;
+	let lastRawResponse: string | null = null;
+	const startedAt = performance.now();
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			const { text, usage } = await generateText({
-				model: openrouter(JUDGE_MODEL),
-				system: "You are an impartial judge scoring answers to questions. Always respond with valid JSON.",
+				model: openrouter(getJudgeModel()),
+				system: JUDGE_SYSTEM_PROMPT,
 				prompt,
+				abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
 			});
+			lastRawResponse = text;
 
 			let parsed: Partial<NuggetJudgeResult> | null = null;
 
@@ -233,8 +277,19 @@ export async function evaluateNuggetJudge(
 					scores,
 					reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : "(no reasoning)",
 					token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+					status: "completed",
+					attempt,
+					latency_ms: Math.round(performance.now() - startedAt),
+					prompt_version: "beam-nugget-judge-v1",
+					prompt_sha256: sha256Text(prompt),
+					prompt_characters: prompt.length,
+					system_prompt: JUDGE_SYSTEM_PROMPT,
+					prompt,
+					raw_response: text,
+					parse_status: "parsed",
 				};
 			}
+			lastError = new Error("judge response did not contain a valid scores array");
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 			console.log(`[Judge] Attempt ${attempt}/${maxRetries} failed: ${lastError.message.substring(0, 80)}`);
@@ -249,6 +304,17 @@ export async function evaluateNuggetJudge(
 		scores: atoms.map(() => 0),
 		reasoning: `judge failure: ${lastError?.message ?? "unknown"}`,
 		token_usage: unavailableTokenUsage(),
+		status: "execution_error",
+		attempt: maxRetries,
+		latency_ms: Math.round(performance.now() - startedAt),
+		prompt_version: "beam-nugget-judge-v1",
+		prompt_sha256: sha256Text(prompt),
+		prompt_characters: prompt.length,
+		system_prompt: JUDGE_SYSTEM_PROMPT,
+		prompt,
+		raw_response: lastRawResponse,
+		parse_status: "failed",
+		error: lastError?.message ?? "unknown judge failure",
 	};
 }
 

--- a/benchmark/beam/src/opencontext-client.ts
+++ b/benchmark/beam/src/opencontext-client.ts
@@ -12,9 +12,10 @@
  * (OPENROUTER_API_KEY, OPENROUTER_ANSWER_MODEL).
  */
 
-import { tokenUsage, type TokenUsage } from "../../run-support";
+import { type TokenUsage, tokenUsage } from "../../run-support";
 
 export const DEFAULT_OPENCONTEXT_PORT = 7421;
+const MODEL_REQUEST_TIMEOUT_MS = 300_000;
 
 export function getOpencontextBaseUrl(): string {
 	if (process.env.OPENCONTEXT_URL) return process.env.OPENCONTEXT_URL;
@@ -61,7 +62,34 @@ export interface BenchRawMessage {
 	metadata?: Record<string, unknown>;
 }
 
-const INGEST_BATCH_SIZE = 25;
+export const INGEST_BATCH_SIZE = 25;
+
+export interface IngestMessagesResult {
+	inserted: number;
+	warnings: unknown[];
+	batches: IngestBatchTrace[];
+}
+
+export interface IngestBatchTrace {
+	batch_index: number;
+	message_ids: string[];
+	requested: number;
+	inserted: number;
+	status: "completed" | "partial" | "execution_error";
+	latency_ms: number;
+	warnings: unknown[];
+	error?: string;
+}
+
+export class IngestMessagesError extends Error {
+	constructor(
+		message: string,
+		readonly result: IngestMessagesResult,
+	) {
+		super(message);
+		this.name = "IngestMessagesError";
+	}
+}
 
 /**
  * Ingest messages into the OpenContext memory store. `embedOnInsert: true`
@@ -72,30 +100,69 @@ export async function ingestMessages(
 	messages: BenchRawMessage[],
 	baseUrl = getOpencontextBaseUrl(),
 	userId = BENCH_USER_ID,
-): Promise<number> {
+): Promise<IngestMessagesResult> {
 	let inserted = 0;
+	const warnings: unknown[] = [];
+	const batches: IngestBatchTrace[] = [];
 	for (let i = 0; i < messages.length; i += INGEST_BATCH_SIZE) {
 		const batch = messages.slice(i, i + INGEST_BATCH_SIZE).map((m) => ({
 			...m,
 			userId,
 		}));
-		const res = await fetch(`${baseUrl}/v1/raw-messages`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				userId,
-				messages: batch,
-				embedOnInsert: true,
-			}),
-			signal: AbortSignal.timeout(600_000),
-		});
-		if (!res.ok) {
-			throw new Error(`ingest /v1/raw-messages failed: ${res.status} ${await res.text()}`);
+		const batchIndex = i / INGEST_BATCH_SIZE;
+		const startedAt = performance.now();
+		try {
+			const res = await fetch(`${baseUrl}/v1/raw-messages`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					userId,
+					messages: batch,
+					embedOnInsert: true,
+				}),
+				signal: AbortSignal.timeout(600_000),
+			});
+			if (!res.ok) {
+				throw new Error(`ingest /v1/raw-messages failed: ${res.status} ${await res.text()}`);
+			}
+			const data = (await res.json()) as { count?: number; warnings?: unknown[] };
+			const batchInserted = data.count ?? batch.length;
+			const batchWarnings = data.warnings ?? [];
+			inserted += batchInserted;
+			warnings.push(...batchWarnings);
+			const status = batchInserted === batch.length ? "completed" : "partial";
+			batches.push({
+				batch_index: batchIndex,
+				message_ids: batch.map((message) => message.messageId),
+				requested: batch.length,
+				inserted: batchInserted,
+				status,
+				latency_ms: Math.round(performance.now() - startedAt),
+				warnings: batchWarnings,
+			});
+			if (status === "partial") {
+				throw new IngestMessagesError(
+					`ingest inserted ${batchInserted} of ${batch.length} messages in batch ${batchIndex}`,
+					{ inserted, warnings, batches },
+				);
+			}
+		} catch (error) {
+			if (error instanceof IngestMessagesError) throw error;
+			const message = error instanceof Error ? error.message : String(error);
+			batches.push({
+				batch_index: batchIndex,
+				message_ids: batch.map((item) => item.messageId),
+				requested: batch.length,
+				inserted: 0,
+				status: "execution_error",
+				latency_ms: Math.round(performance.now() - startedAt),
+				warnings: [],
+				error: message,
+			});
+			throw new IngestMessagesError(message, { inserted, warnings, batches });
 		}
-		const data = (await res.json()) as { count?: number };
-		inserted += data.count ?? batch.length;
 	}
-	return inserted;
+	return { inserted, warnings, batches };
 }
 
 export interface MemorySearchHit {
@@ -103,6 +170,16 @@ export interface MemorySearchHit {
 	content: string;
 	similarity: number;
 	metadata: Record<string, unknown>;
+	signals?: Record<string, unknown>;
+}
+
+export interface MemorySearchResponse {
+	query: string;
+	sources: string[];
+	results: MemorySearchHit[];
+	count: number;
+	warnings: unknown[];
+	reasoning?: unknown;
 }
 
 /** Retrieve relevant memories for a question. */
@@ -111,7 +188,7 @@ export async function searchMemory(
 	limit = 8,
 	baseUrl = getOpencontextBaseUrl(),
 	userId = BENCH_USER_ID,
-): Promise<MemorySearchHit[]> {
+): Promise<MemorySearchResponse> {
 	const res = await fetch(`${baseUrl}/v1/search`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
@@ -127,19 +204,34 @@ export async function searchMemory(
 		throw new Error(`search /v1/search failed: ${res.status} ${await res.text()}`);
 	}
 	const data = (await res.json()) as {
+		query?: string;
+		sources?: string[];
+		count?: number;
+		warnings?: unknown[];
+		reasoning?: unknown;
 		results?: Array<{
 			id: string;
 			content: string;
 			similarity: number;
 			metadata?: Record<string, unknown>;
+			signals?: Record<string, unknown>;
 		}>;
 	};
-	return (data.results ?? []).map((r) => ({
+	const results = (data.results ?? []).map((r) => ({
 		id: r.id,
 		content: r.content,
 		similarity: r.similarity,
 		metadata: r.metadata ?? {},
+		...(r.signals ? { signals: r.signals } : {}),
 	}));
+	return {
+		query: data.query ?? query,
+		sources: data.sources ?? [],
+		results,
+		count: data.count ?? results.length,
+		warnings: data.warnings ?? [],
+		...(data.reasoning === undefined ? {} : { reasoning: data.reasoning }),
+	};
 }
 
 /**
@@ -202,6 +294,7 @@ export async function generateAnswer(prompt: string, system?: string): Promise<G
 		model: openrouter(process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"),
 		...(system ? { system } : {}),
 		prompt,
+		abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
 	});
 	return {
 		text,

--- a/benchmark/beam/src/types.ts
+++ b/benchmark/beam/src/types.ts
@@ -45,6 +45,26 @@ export interface BeamTurn {
 	speaker: string;
 	text: string;
 	timestamp?: string;
+	/** Stable id from the upstream BEAM chat row, used for provenance only. */
+	source_id?: string;
+	/** Optional upstream display/index label (for example `1,1`). */
+	source_index?: string;
+}
+
+export interface BeamQuestionSource {
+	/** Upstream chat turn ids that contain the evidence for this question. */
+	source_chat_ids: string[];
+	conversation_references: string[];
+	plan_references: string[];
+	why_unanswerable?: string;
+}
+
+export interface BeamDatasetSource {
+	repository: string;
+	config: string;
+	split: string;
+	revision: string;
+	converter_schema_version: string;
 }
 
 /**
@@ -64,6 +84,123 @@ export interface BeamProbingQuestion {
 	 * is nugget-based (atoms), not against this string.
 	 */
 	gold_answer?: string;
+	/** Upstream provenance. Empty ids mean the source did not provide an exact mapping. */
+	source: BeamQuestionSource;
+}
+
+export const BEAM_TRACE_SCHEMA_VERSION = "1.1";
+
+export type BeamExecutionStatus = "completed" | "execution_error";
+
+export type BeamFailureStage =
+	| "none"
+	| "dataset_reference_missing"
+	| "dataset_reference_partial"
+	| "ingest_or_index_error"
+	| "retrieval_error"
+	| "retrieval_miss"
+	| "retrieval_partial"
+	| "answerer_error"
+	| "context_present_answer_failed"
+	| "judge_error"
+	| "provider_error";
+
+export interface BeamChunkTrace {
+	schema_version: string;
+	entry_id: string;
+	scale: BeamScale;
+	message_id: string;
+	chunk_index: number;
+	ingest_batch_index: number;
+	turn_start: number;
+	turn_end: number;
+	source_turn_ids: string[];
+	content_sha256: string;
+	content_characters: number;
+	first_timestamp: string | null;
+	last_timestamp: string | null;
+	ingest_status: "pending" | "not_attempted" | "completed" | "partial" | "execution_error";
+	ingest_latency_ms: number | null;
+	ingest_warnings: unknown[];
+	error?: string;
+}
+
+export interface BeamRetrievalHitTrace {
+	rank: number;
+	id: string;
+	similarity: number;
+	signals: Record<string, unknown> | null;
+	metadata: Record<string, unknown>;
+	content_sha256: string;
+	content_characters: number;
+	content_excerpt: string;
+	content: string;
+	source_turn_ids: string[];
+	matched_source_turn_ids: string[];
+	relevant: boolean | null;
+}
+
+export interface BeamRetrievalTrace {
+	status: "completed" | "execution_error";
+	query: string;
+	user_id: string;
+	top_k: number;
+	strategy: "daemon-default";
+	latency_ms: number;
+	response_query: string;
+	response_sources: string[];
+	response_count: number;
+	response_warnings: unknown[];
+	response_reasoning: unknown | null;
+	hits: BeamRetrievalHitTrace[];
+	retrieval_applicable: boolean;
+	required_source_turn_ids: string[];
+	available_source_turn_ids: string[];
+	missing_source_turn_ids: string[];
+	retrieved_source_turn_ids: string[];
+	missed_source_turn_ids: string[];
+	dataset_source_coverage: number | null;
+	source_recall_at_k: number | null;
+	retrievable_source_recall_at_k: number | null;
+	all_required_sources_retrieved: boolean | null;
+	hit_at_k: number | null;
+	first_relevant_rank: number | null;
+	mrr: number | null;
+	precision_at_k: number | null;
+	relevant_hit_precision: number | null;
+	error?: string;
+}
+
+export interface BeamModelCallTrace {
+	model: string;
+	status: "completed" | "skipped" | "execution_error";
+	attempt: number;
+	latency_ms: number;
+	prompt_version: string;
+	prompt_sha256: string | null;
+	prompt_characters: number;
+	system_prompt: string | null;
+	prompt: string | null;
+	token_usage: TokenUsage;
+	error?: string;
+}
+
+export interface BeamAnswerTrace extends BeamModelCallTrace {
+	included_hit_ids: string[];
+	cited_hit_ids: string[];
+	cited_relevant_hit_ids: string[];
+	attribution_status: "supported" | "unsupported" | "uncited" | "not_applicable";
+}
+
+export interface BeamJudgeTrace extends BeamModelCallTrace {
+	raw_response: string | null;
+	parse_status: "parsed" | "skipped" | "failed";
+}
+
+export interface BeamQuestionTrace {
+	retrieval: BeamRetrievalTrace | null;
+	answerer: BeamAnswerTrace | null;
+	judge: BeamJudgeTrace | null;
 }
 
 /**
@@ -88,6 +225,7 @@ export interface BeamConversation {
  */
 export interface BeamDatasetFile {
 	scale: BeamScale;
+	source?: BeamDatasetSource;
 	conversations: BeamConversation[];
 }
 
@@ -116,9 +254,20 @@ export interface EvaluationResult {
  * Prediction result for a single question.
  */
 export interface Prediction {
+	trace_schema_version: string;
+	entry_id: string;
+	conversation_sha256: string;
+	question_sha256: string;
+	status: BeamExecutionStatus;
+	attempt: number;
+	execution_error?: { stage: string; message: string };
 	token_usage: TokenUsage;
+	answerer_model: string;
+	judge_model: string;
 	question_id: string;
 	question: string;
+	gold_answer: string | null;
+	source: BeamQuestionSource;
 	response: string;
 	prediction: string;
 	/**
@@ -142,6 +291,8 @@ export interface Prediction {
 	 */
 	nugget_pass: boolean;
 	judge_reasoning: string;
+	trace: BeamQuestionTrace;
+	failure_stage: BeamFailureStage;
 	/**
 	 * True if the agent produced a refusal/abstention for abstention-category
 	 * questions (recorded separately for debugging).

--- a/packages/sqlite/src/lexical-search.test.ts
+++ b/packages/sqlite/src/lexical-search.test.ts
@@ -91,4 +91,41 @@ describe("SQLiteRawMessageManager.lexicalSearchMessages", () => {
 
 		await manager.close();
 	});
+
+	it("preserves benchmark provenance metadata in semantic and lexical hits", async () => {
+		const manager = new SQLiteRawMessageManager({
+			dbPath: join(scratchDir, "store.db"),
+			enableVectorSearch: false,
+		});
+		await manager.init();
+
+		await manager.storeMessage(
+			makeMessage({
+				messageId: "beam-conv-1-chunk-0",
+				content: "Berlin provenance marker",
+				embedding: [1, 0, 0],
+				embeddingModel: "fixture",
+				metadata: {
+					entryId: "conv-1",
+					chunkIndex: 0,
+					sourceTurnIds: ["41", "42"],
+				},
+			}),
+		);
+
+		const semanticHits = await manager.searchMessagesSemantically({
+			userId: "u1",
+			queryEmbedding: [1, 0, 0],
+			threshold: 0.9,
+		});
+		const lexicalHits = await manager.lexicalSearchMessages({ userId: "u1", keywords: ["Berlin"] });
+
+		for (const hit of [...semanticHits, ...lexicalHits]) {
+			expect(hit.metadata.entryId).toBe("conv-1");
+			expect(hit.metadata.chunkIndex).toBe(0);
+			expect(hit.metadata.sourceTurnIds).toEqual(["41", "42"]);
+		}
+
+		await manager.close();
+	});
 });

--- a/packages/sqlite/src/raw-message-manager.ts
+++ b/packages/sqlite/src/raw-message-manager.ts
@@ -104,7 +104,7 @@ export interface SQLiteRawMessageSemanticSearchResult {
 	id: string;
 	content: string;
 	similarity: number;
-	metadata: {
+	metadata: Record<string, unknown> & {
 		userId: string;
 		platform: string;
 		botId: string;
@@ -142,7 +142,7 @@ export interface SQLiteRawMessageLexicalSearchResult {
 	content: string;
 	similarity: number;
 	bm25Rank: number;
-	metadata: {
+	metadata: Record<string, unknown> & {
 		userId: string;
 		platform: string;
 		botId: string;
@@ -1145,6 +1145,7 @@ export class SQLiteRawMessageManager implements RawMessageStorageManager {
 				similarity: sqliteDistanceToScore(-row.bm25_rank),
 				bm25Rank: row.bm25_rank,
 				metadata: {
+					...(message.metadata ?? {}),
 					userId: message.userId,
 					platform: message.platform,
 					botId: message.botId,
@@ -1483,6 +1484,7 @@ export class SQLiteRawMessageManager implements RawMessageStorageManager {
 			content: message.archivedAt ? "" : message.content,
 			similarity,
 			metadata: {
+				...(message.metadata ?? {}),
 				userId: message.userId,
 				platform: message.platform,
 				botId: message.botId,


### PR DESCRIPTION
## Summary

This PR adds an end-to-end diagnostic evidence chain to the existing BEAM benchmark and includes the first complete BEAM 128k test report.

## What changed

### Dataset provenance

- Pin the Hugging Face repository, config, split, and revision for all BEAM scales.
- Support the currently published BEAM schemas:
  - nested chat layouts;
  - stringified `probing_questions` grouped by category;
  - `time_anchor`;
  - `rubric`;
  - `ideal_answer` and related gold-answer fields.
- Preserve upstream turn IDs, source indexes, conversation references, plan references, and `source_chat_ids`.
- Stream converted conversations to disk so the 10M conversion does not require keeping the complete normalized dataset in memory.
- Record the upstream dataset identity and converter schema version in generated JSON.

### Ingest and chunk evidence

- Map upstream turn IDs to deterministic BEAM chunk/message IDs.
- Record chunk boundaries, content hashes, character counts, timestamp ranges, ingest batch indexes, status, latency, warnings, and errors.
- Preserve benchmark provenance metadata in both SQLite semantic and lexical search results.

### Retrieval evidence

- Preserve the complete daemon search response, warnings, reasoning metadata, and per-hit score signals.
- Record ranked Top-K contents and map each hit back to upstream source turns.
- Add diagnostic retrieval metrics:
  - Source Recall@K;
  - retrievable Source Recall@K;
  - Hit@K;
  - Precision@K;
  - MRR;
  - complete-source retrieval rate;
  - dataset source coverage.
- Keep questions without upstream source IDs scoreable while marking retrieval attribution as unavailable.

### Answerer and Judge evidence

- Record the Answerer and Judge model identities.
- Record prompt versions, prompt hashes, exact prompts, responses, latency, attempts, token usage, and execution status.
- Preserve the Judge raw response and parse status.
- Record answer citations and whether cited excerpts contain upstream gold sources.
- Classify failures conservatively as:
  - dataset reference missing;
  - ingest/index error;
  - retrieval error;
  - retrieval miss;
  - retrieval partial;
  - Answerer error;
  - context present but answer failed;
  - Judge error;
  - provider error.

### Checkpoint and resume behavior

- Reuse completed checkpoints regardless of whether the answer passed or failed.
- Retry execution errors only.
- Validate checkpoints against:
  - trace schema version;
  - conversation fingerprint;
  - question fingerprint;
  - Answerer model;
  - Judge model.
- Ignore legacy or mismatched checkpoints instead of silently mixing results.
- Make the Judge model explicitly configurable through `OPENROUTER_JUDGE_MODEL`.

### Output, CI, and documentation

- Write a compact result JSON plus:
  - `*.trace.jsonl` for per-question evidence;
  - `*.chunks.jsonl` for ingest and provenance evidence.
- Add BEAM diagnostic tests to CI.
- Document the evidence-chain artifacts, source mapping, checkpoint behavior, and provider configuration.
- Add `benchmark/beam/docs/128k-v1-test-report.md` with the first complete 128k diagnostic result and identified limitations.

## 128k diagnostic run

The completed diagnostic run covered all 20 conversations and 400 questions:

- completed: 400 / 400;
- execution errors: 0;
- Nugget Mean: 0.5305;
- Pass Rate: 56.75% (227 / 400);
- Hit@8: 92.11%;
- Mean Source Recall@8: 0.8027;
- All Required Sources Retrieved: 65.35%;
- total provider-reported usage: 31,456,385 tokens.

The evidence chain exposed several issues that could not be identified from the headline score alone:

- 3,199 of 3,200 final Top-K hits were lexical-only;
- 20-turn chunks averaged about 41.7K characters;
- Answerer prompts averaged about 74K tokens per question;
- 94 failures occurred even though all annotated source turns were present in the retrieved chunks;
- event ordering, temporal reasoning, summarization, and knowledge updates were the weakest categories;
- at least one question lacked upstream source IDs;
- at least one question had conflicting gold-answer and nugget-atom values.

The report treats this run as a diagnostic baseline, not an official leaderboard result or a pure measurement of OpenContext semantic retrieval.

## Scoring compatibility

The diagnostic fields do not participate in scoring.

This PR does not change:

- the BEAM nugget atoms;
- the `0.0 / 0.5 / 1.0` Judge rubric;
- `nugget_mean`;
- the `nugget_pass >= 0.5` threshold;
- the Answerer prompt;
- Top-K;
- the benchmark category definitions.

## Validation

- [x] `pnpm --filter @melandlabs/benchmark-beam test`
  - 6 tests passed
- [x] `pnpm --filter @melandlabs/benchmark-beam typecheck`
- [x] BEAM staged-source Biome lint
  - 12 files checked
- [x] `python -m unittest test_convert.py`
  - 8 tests passed
- [x] `pnpm --filter @melandlabs/sqlite exec vitest run src/lexical-search.test.ts`
  - 4 tests passed
- [x] Full BEAM 128k diagnostic run
  - 400 / 400 completed
  - 0 execution errors

## Notes

- Generated datasets, checkpoints, databases, and raw result artifacts remain ignored.
- The committed report contains the reproducible summary; raw trace artifacts are retained separately.
- A future formal comparison should use a fresh database and `--no-resume`.
- The next benchmark iteration should first verify that semantic retrieval contributes to the final Top-K and reduce the chunk/prompt size before running larger BEAM scales.