### PR TITLE
feat(memory-store): support trusted applicability-scoped search

### DIFF
--- a/.changeset/trusted-memory-applicability.md
+++ b/.changeset/trusted-memory-applicability.md
@@ -1,0 +1,6 @@
+---
+"@melandlabs/memory-store": minor
+"@melandlabs/memory-consolidation": patch
+---
+
+Add a trusted in-process applicability context to unified memory search, propagate one resolved timestamp through every retrieval provider and reasoning sub-search, and fail closed for built-in raw-message sources that cannot enforce the requested scope. Align graph retrieval on the shared exact-match and validity-window contract.

--- a/packages/ai/memory-consolidation/src/graph-retrieval.test.ts
+++ b/packages/ai/memory-consolidation/src/graph-retrieval.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { MemoryGraphSnapshot } from "./graph-contracts";
-import { buildGraphAwareRetrievalDryRun } from "./graph-retrieval";
+import {
+	DefaultGraphAwareRetriever,
+	applicabilityMatchesTrustedContexts,
+	buildGraphAwareRetrievalDryRun,
+} from "./graph-retrieval";
 
 const OWNER = { userId: "u1" };
 const NOW = 1_700_000_000_000;
@@ -16,6 +20,180 @@ function snapshot(overrides: Partial<MemoryGraphSnapshot> = {}): MemoryGraphSnap
 		...overrides,
 	};
 }
+
+describe("applicabilityMatchesTrustedContexts", () => {
+	it("keeps global memories eligible under every explicit context list", () => {
+		expect(applicabilityMatchesTrustedContexts(undefined, [], NOW)).toBe(true);
+		expect(applicabilityMatchesTrustedContexts({ scope: "global" }, [], NOW)).toBe(true);
+		expect(
+			applicabilityMatchesTrustedContexts({ scope: "global" }, [{ scope: "project", key: "project-a" }], NOW),
+		).toBe(true);
+	});
+
+	it("requires exact scope and key equality for scoped memories", () => {
+		const projectA = { scope: "project" as const, key: "project-a" };
+		expect(applicabilityMatchesTrustedContexts(projectA, [projectA], NOW)).toBe(true);
+		expect(applicabilityMatchesTrustedContexts(projectA, [{ scope: "project", key: "project-b" }], NOW)).toBe(
+			false,
+		);
+		expect(applicabilityMatchesTrustedContexts(projectA, [{ scope: "task", key: "project-a" }], NOW)).toBe(
+			false,
+		);
+		expect(applicabilityMatchesTrustedContexts(projectA, [{ scope: "project" }], NOW)).toBe(false);
+		expect(
+			applicabilityMatchesTrustedContexts(
+				{ scope: "project" },
+				[{ scope: "project", key: "project-a" }],
+				NOW,
+			),
+		).toBe(false);
+	});
+
+	it("treats multiple trusted contexts as additive", () => {
+		const contexts = [
+			{ scope: "task" as const, key: "task-a" },
+			{ scope: "project" as const, key: "project-b" },
+		];
+		expect(applicabilityMatchesTrustedContexts({ scope: "task", key: "task-a" }, contexts, NOW)).toBe(true);
+		expect(applicabilityMatchesTrustedContexts({ scope: "project", key: "project-b" }, contexts, NOW)).toBe(
+			true,
+		);
+		expect(applicabilityMatchesTrustedContexts({ scope: "project", key: "project-c" }, contexts, NOW)).toBe(
+			false,
+		);
+	});
+
+	it("requires both the memory and its matching context to be active", () => {
+		const projectA = { scope: "project" as const, key: "project-a" };
+		expect(applicabilityMatchesTrustedContexts({ ...projectA, validFrom: NOW + 1 }, [projectA], NOW)).toBe(
+			false,
+		);
+		expect(applicabilityMatchesTrustedContexts({ ...projectA, validUntil: NOW - 1 }, [projectA], NOW)).toBe(
+			false,
+		);
+		expect(applicabilityMatchesTrustedContexts(projectA, [{ ...projectA, validFrom: NOW + 1 }], NOW)).toBe(
+			false,
+		);
+		expect(applicabilityMatchesTrustedContexts(projectA, [{ ...projectA, validUntil: NOW - 1 }], NOW)).toBe(
+			false,
+		);
+		expect(
+			applicabilityMatchesTrustedContexts(
+				{ ...projectA, validFrom: NOW, validUntil: NOW },
+				[{ ...projectA, validFrom: NOW, validUntil: NOW }],
+				NOW,
+			),
+		).toBe(true);
+	});
+
+	it("evaluates windows at the supplied historical instant", () => {
+		const projectA = { scope: "project" as const, key: "project-a", validUntil: NOW - 500 };
+		expect(applicabilityMatchesTrustedContexts(projectA, [projectA], NOW - 1_000)).toBe(true);
+		expect(applicabilityMatchesTrustedContexts(projectA, [projectA], NOW)).toBe(false);
+		expect(applicabilityMatchesTrustedContexts({ scope: "global", validUntil: NOW - 500 }, [], NOW)).toBe(
+			false,
+		);
+	});
+});
+
+describe("DefaultGraphAwareRetriever applicability", () => {
+	it("returns global plus exactly matching scoped baseline nodes", async () => {
+		const retriever = new DefaultGraphAwareRetriever();
+		const result = await retriever.compare({
+			ownerScope: OWNER,
+			query: "q",
+			baselineNodeIds: ["global", "project-a", "project-b"],
+			snapshot: snapshot({
+				nodes: [
+					{
+						id: "global",
+						ownerScope: OWNER,
+						type: "raw",
+						createdAt: NOW,
+						visibility: "default",
+						applicability: { scope: "global" },
+					},
+					{
+						id: "project-a",
+						ownerScope: OWNER,
+						type: "raw",
+						createdAt: NOW,
+						visibility: "default",
+						applicability: { scope: "project", key: "project-a" },
+					},
+					{
+						id: "project-b",
+						ownerScope: OWNER,
+						type: "raw",
+						createdAt: NOW,
+						visibility: "default",
+						applicability: { scope: "project", key: "project-b" },
+					},
+				],
+			}),
+			applicabilityContexts: [{ scope: "project", key: "project-a" }],
+			visibilityMode: "default",
+			asOf: new Date(NOW).toISOString(),
+		});
+
+		expect(result.rankedNodeIds).toEqual(["global", "project-a"]);
+	});
+
+	it("excludes scoped nodes when the matching trusted context is not active", async () => {
+		const retriever = new DefaultGraphAwareRetriever();
+		const result = await retriever.compare({
+			ownerScope: OWNER,
+			query: "q",
+			baselineNodeIds: ["project-a"],
+			snapshot: snapshot({
+				nodes: [
+					{
+						id: "project-a",
+						ownerScope: OWNER,
+						type: "raw",
+						createdAt: NOW,
+						visibility: "default",
+						applicability: { scope: "project", key: "project-a" },
+					},
+				],
+			}),
+			applicabilityContexts: [{ scope: "project", key: "project-a", validUntil: NOW - 1 }],
+			visibilityMode: "default",
+			asOf: new Date(NOW).toISOString(),
+		});
+
+		expect(result.rankedNodeIds).toEqual([]);
+	});
+
+	it("does not expand clusters from a different applicability context", async () => {
+		const retriever = new DefaultGraphAwareRetriever();
+		const result = await retriever.compare({
+			ownerScope: OWNER,
+			query: "q",
+			baselineNodeIds: ["n1"],
+			snapshot: snapshot({
+				nodes: [{ id: "n1", ownerScope: OWNER, type: "raw", createdAt: NOW, visibility: "default" }],
+				clusters: [
+					{
+						clusterId: "project-b-cluster",
+						ownerScope: OWNER,
+						nodeIds: ["n1"],
+						lifecycleStatus: "active",
+						updatedAt: NOW,
+						reasonCodes: [],
+						applicability: { scope: "project", key: "project-b" },
+					},
+				],
+			}),
+			applicabilityContexts: [{ scope: "project", key: "project-a" }],
+			visibilityMode: "default",
+			asOf: new Date(NOW).toISOString(),
+		});
+
+		expect(result.rankedNodeIds).toEqual(["n1"]);
+		expect(result.expandedClusterIds).toEqual([]);
+	});
+});
 
 describe("buildGraphAwareRetrievalDryRun", () => {
 	it("returns baseline nodes that exist and are visible", () => {
@@ -237,5 +415,31 @@ describe("buildGraphAwareRetrievalDryRun", () => {
 		});
 		expect(result.rankedNodeIds).toHaveLength(0);
 		expect(result.withheldBaselineNodes[0].reason).toBe("out-of-applicability");
+	});
+
+	it("evaluates applicability at an explicitly requested asOf instant", () => {
+		const result = buildGraphAwareRetrievalDryRun({
+			ownerScope: OWNER,
+			query: "q",
+			baselineNodeIds: ["n1"],
+			snapshot: snapshot({
+				nodes: [
+					{
+						id: "n1",
+						ownerScope: OWNER,
+						type: "raw",
+						createdAt: NOW,
+						visibility: "default",
+						applicability: { scope: "project", key: "project-a", validFrom: NOW + 100 },
+					},
+				],
+			}),
+			visibilityMode: "default",
+			applicabilityContexts: [{ scope: "project", key: "project-a" }],
+			asOf: new Date(NOW + 200).toISOString(),
+		});
+
+		expect(result.rankedNodeIds).toEqual(["n1"]);
+		expect(result.withheldBaselineNodes).toEqual([]);
 	});
 });

--- a/packages/ai/memory-consolidation/src/graph-retrieval.ts
+++ b/packages/ai/memory-consolidation/src/graph-retrieval.ts
@@ -42,12 +42,17 @@ function applicabilityIsActive(applicability: MemoryApplicabilityContext | undef
 }
 
 /**
- * Retrieval is directional: global candidates are always eligible, while a
- * narrower candidate requires an exact trusted request scope/key match.
+ * Canonical applicability matcher for trusted retrieval contexts.
+ *
+ * Missing applicability is treated as global. Global candidates remain
+ * eligible for every explicit context list (including an empty list), while
+ * scoped candidates require an active context with an exact scope/key match.
+ * Candidate and matching-context validity windows are inclusive and evaluated
+ * at the caller-supplied `now` instant.
  */
 export function applicabilityMatchesTrustedContexts(
 	candidate: MemoryApplicabilityContext | undefined,
-	trustedContexts: MemoryApplicabilityContext[] | undefined,
+	trustedContexts: readonly MemoryApplicabilityContext[] | undefined,
 	now: number,
 ): boolean {
 	if (!applicabilityIsActive(candidate, now)) return false;
@@ -65,7 +70,7 @@ export function applicabilityMatchesTrustedContexts(
 function scopedNodesById(
 	nodes: MemoryGraphNode[],
 	ownerScope: OwnerScope,
-	applicabilityContexts: MemoryApplicabilityContext[] | undefined,
+	applicabilityContexts: readonly MemoryApplicabilityContext[] | undefined,
 	now: number,
 ): Map<string, MemoryGraphNode> {
 	return new Map(
@@ -83,7 +88,7 @@ function scopedEdges(
 	edges: MemoryGraphEdge[],
 	ownerScope: OwnerScope,
 	includeHistorical = false,
-	applicabilityContexts?: MemoryApplicabilityContext[],
+	applicabilityContexts?: readonly MemoryApplicabilityContext[],
 	now = Date.now(),
 ): MemoryGraphEdge[] {
 	return edges.filter(
@@ -98,7 +103,7 @@ function scopedEdges(
 function scopedClusters(
 	clusters: MemoryGraphClusterSnapshot[],
 	ownerScope: OwnerScope,
-	applicabilityContexts: MemoryApplicabilityContext[] | undefined,
+	applicabilityContexts: readonly MemoryApplicabilityContext[] | undefined,
 	now: number,
 ): MemoryGraphClusterSnapshot[] {
 	return clusters.filter(
@@ -483,7 +488,7 @@ export function buildGraphAwareRetrievalDryRun(
 	const includeDeprecated = input.includeDeprecated === true;
 	const auditMode = input.visibilityMode === "audit";
 	const conflictMode = input.visibilityMode === "conflict";
-	const applicabilityNow = input.snapshot.capturedAt ?? Date.now();
+	const applicabilityNow = parseAsOf(input.asOf, input.snapshot.capturedAt);
 	const nodesById = scopedNodesById(
 		input.snapshot.nodes,
 		input.ownerScope,
@@ -679,30 +684,6 @@ export function applicabilityContains(
 	return true;
 }
 
-function isApplicable(
-	applicability: MemoryApplicabilityContext | undefined,
-	contexts: MemoryApplicabilityContext[] | undefined,
-	asOfMs: number,
-): boolean {
-	if (!applicability) return true;
-	if (typeof applicability.validFrom === "number" && asOfMs < applicability.validFrom) {
-		return false;
-	}
-	if (typeof applicability.validUntil === "number" && asOfMs > applicability.validUntil) {
-		return false;
-	}
-	if (!contexts || contexts.length === 0) {
-		return applicability.scope === "global";
-	}
-	return contexts.some((ctx) => {
-		if (ctx.scope !== applicability.scope) return false;
-		if (applicability.key && ctx.key && applicability.key !== ctx.key) {
-			return false;
-		}
-		return true;
-	});
-}
-
 export class DefaultGraphAwareRetriever implements GraphAwareRetriever {
 	async compare(input: GraphAwareRetrievalInput): Promise<GraphAwareRetrievalResult> {
 		const reasonCodes: string[] = [];
@@ -718,7 +699,7 @@ export class DefaultGraphAwareRetriever implements GraphAwareRetriever {
 			if (node.visibility === "audit-only" && input.visibilityMode !== "audit") {
 				continue;
 			}
-			if (!isApplicable(node.applicability, input.applicabilityContexts, asOfMs)) {
+			if (!applicabilityMatchesTrustedContexts(node.applicability, input.applicabilityContexts, asOfMs)) {
 				continue;
 			}
 			applicableNodeIds.add(node.id);
@@ -731,13 +712,17 @@ export class DefaultGraphAwareRetriever implements GraphAwareRetriever {
 			if (!applicableNodeIds.has(edge.fromNodeId) || !applicableNodeIds.has(edge.toNodeId)) {
 				continue;
 			}
-			if (!applicabilityContains(edge.applicability, asOfMs)) {
+			if (!applicabilityMatchesTrustedContexts(edge.applicability, input.applicabilityContexts, asOfMs)) {
 				continue;
 			}
 			if (baselineSet.has(edge.fromNodeId) || baselineSet.has(edge.toNodeId)) {
 				for (const cluster of input.snapshot.clusters) {
 					if (
-						!applicabilityContains(cluster.applicability, asOfMs) ||
+						!applicabilityMatchesTrustedContexts(
+							cluster.applicability,
+							input.applicabilityContexts,
+							asOfMs,
+						) ||
 						!cluster.nodeIds.includes(edge.fromNodeId) ||
 						!cluster.nodeIds.includes(edge.toNodeId)
 					) {
@@ -749,7 +734,9 @@ export class DefaultGraphAwareRetriever implements GraphAwareRetriever {
 		}
 
 		for (const cluster of input.snapshot.clusters) {
-			if (!applicabilityContains(cluster.applicability, asOfMs)) continue;
+			if (!applicabilityMatchesTrustedContexts(cluster.applicability, input.applicabilityContexts, asOfMs)) {
+				continue;
+			}
 			if (cluster.nodeIds.some((id) => baselineSet.has(id))) {
 				expandedClusterIds.add(cluster.clusterId);
 			}

--- a/packages/memory-store/src/config.ts
+++ b/packages/memory-store/src/config.ts
@@ -34,6 +34,7 @@ import type { FactType } from "@melandlabs/contracts";
 import type { DerivedFact } from "@melandlabs/contracts/derived-fact";
 import type { EntityEdge } from "@melandlabs/contracts/entity-edge";
 import type { Peer } from "@melandlabs/contracts/peer";
+import type { MemoryApplicabilityContext } from "@melandlabs/memory-consolidation";
 import type { RawMessage } from "./contracts";
 import type { IterativeRecallPlanner } from "./search/iterative-recall";
 import type { QueryRewriter } from "./search/query-rewriter";
@@ -137,6 +138,19 @@ export interface MemorySummaryHit {
 	endTimestamp?: number;
 }
 
+/**
+ * Trusted applicability fields forwarded together to retrieval providers.
+ * They are absent for legacy unscoped searches and always present together
+ * for scoped searches. Providers must enforce the canonical applicability
+ * contract at `applicabilityAt`; these values must not be derived from public
+ * request payloads.
+ */
+export interface SearchProviderApplicabilityInput {
+	applicabilityContexts?: readonly MemoryApplicabilityContext[];
+	/** Epoch milliseconds resolved once at the `search()` boundary. */
+	applicabilityAt?: number;
+}
+
 export interface UnifiedSearchDeps {
 	/** Embed a query string using the active user's provider. */
 	embedQuery?: EmbedQueryFn;
@@ -146,17 +160,19 @@ export interface UnifiedSearchDeps {
 	 * chroma and this are absent, the memory source will return empty
 	 * (with a warning) in standalone mode.
 	 */
-	searchRawMessagesAnn?: (input: {
-		userId: string;
-		queryEmbedding: number[];
-		limit: number;
-		threshold: number;
-		botId?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-		/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */
-		factTypes?: FactType[];
-	}) => Promise<
+	searchRawMessagesAnn?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			queryEmbedding: number[];
+			limit: number;
+			threshold: number;
+			botId?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+			/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */
+			factTypes?: FactType[];
+		},
+	) => Promise<
 		Array<{
 			id: string;
 			content: string;
@@ -165,42 +181,48 @@ export interface UnifiedSearchDeps {
 		}>
 	>;
 	/** RAG over uploaded knowledge documents. Returns a list of chunk hits. */
-	searchKnowledge?: (input: {
-		userId: string;
-		query: string;
-		options: { limit: number; threshold: number; documentIds?: string[] };
-		authToken?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-	}) => Promise<UnifiedSearchKnowledgeResult[]>;
+	searchKnowledge?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			query: string;
+			options: { limit: number; threshold: number; documentIds?: string[] };
+			authToken?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+		},
+	) => Promise<UnifiedSearchKnowledgeResult[]>;
 	/** Semantic search over extracted insights. */
-	searchInsights?: (input: {
-		userId: string;
-		query: string;
-		limit: number;
-		threshold: number;
-		botIds?: string[];
-		includeArchived?: boolean;
-		authToken?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-	}) => Promise<UnifiedSearchInsightsResult[]>;
+	searchInsights?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			query: string;
+			limit: number;
+			threshold: number;
+			botIds?: string[];
+			includeArchived?: boolean;
+			authToken?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+		},
+	) => Promise<UnifiedSearchInsightsResult[]>;
 	/**
 	 * Optional BM25 (lexical) sub-query for the memory source. Mirrors the
 	 * `searchRawMessagesAnn` shape but operates on FTS5 keywords instead of
 	 * dense embeddings. When absent, the unified pipeline skips the lexical
 	 * path and emits a `memory_lexical_search_not_configured` warning.
 	 */
-	searchRawMessagesLexical?: (input: {
-		userId: string;
-		keywords: string[];
-		limit: number;
-		botId?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-		/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */
-		factTypes?: FactType[];
-	}) => Promise<
+	searchRawMessagesLexical?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			keywords: string[];
+			limit: number;
+			botId?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+			/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */
+			factTypes?: FactType[];
+		},
+	) => Promise<
 		Array<{
 			id: string;
 			content: string;
@@ -213,18 +235,20 @@ export interface UnifiedSearchDeps {
 	 * summary tier alongside raw messages and emits a
 	 * `reflect_summaries_unavailable` warning if the call fails.
 	 */
-	searchSummaries?: (input: {
-		userId: string;
-		query: string;
-		keywords: string[];
-		limit: number;
-		threshold: number;
-		dateFrom?: string;
-		dateTo?: string;
-		authToken?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-	}) => Promise<MemorySummaryHit[]>;
+	searchSummaries?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			query: string;
+			keywords: string[];
+			limit: number;
+			threshold: number;
+			dateFrom?: string;
+			dateTo?: string;
+			authToken?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+		},
+	) => Promise<MemorySummaryHit[]>;
 	/**
 	 * Optional entity sub-query provider. Hosts wire this in to opt
 	 * into the `entity` channel of unified search: matches are
@@ -238,14 +262,16 @@ export interface UnifiedSearchDeps {
 	 * own entity store (graph nodes, separate SQLite table, etc.) —
 	 * the SDK never persists entity edges itself.
 	 */
-	entitySearch?: (input: {
-		userId: string;
-		keywords: string[];
-		limit: number;
-		botId?: string;
-		/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
-		peers?: ReadonlyArray<Peer>;
-	}) => Promise<Array<{ messageId: string; label: string; score: number }>>;
+	entitySearch?: (
+		input: SearchProviderApplicabilityInput & {
+			userId: string;
+			keywords: string[];
+			limit: number;
+			botId?: string;
+			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
+			peers?: ReadonlyArray<Peer>;
+		},
+	) => Promise<Array<{ messageId: string; label: string; score: number }>>;
 	/**
 	 * Optional entity extractor wired into the `distill` primitive. The
 	 * extractor receives the raw message text and returns a batch of

--- a/packages/memory-store/src/index.ts
+++ b/packages/memory-store/src/index.ts
@@ -9,6 +9,7 @@
 
 import { type SQLiteVsaStore, getSQLiteVsaStore } from "@melandlabs/sqlite";
 import type { MemoryStoreConfig } from "./config";
+import type { SearchRuntimeContext } from "./search/applicability";
 import type { ApplyConsolidateInput, ApplyConsolidateOutput } from "./search/apply-reflect";
 import { type UnifiedSearch, createUnifiedSearch } from "./search/unified-search";
 import type { SearchInput, SearchOutput } from "./search/utilities";
@@ -31,9 +32,13 @@ export interface MemoryStore {
 	 * lexical fallback. Set `synthesize: true` to opt into the LLM
 	 * synthesis path (formerly `reflect()`).
 	 *
+	 * The optional second argument is trusted in-process context. Omitting it
+	 * preserves legacy unscoped behaviour; an explicit empty applicability list
+	 * requests global-only retrieval.
+	 *
 	 * Use `store.consolidate()` for the agentic write-back loop.
 	 */
-	search(input: SearchInput): Promise<SearchOutput>;
+	search(input: SearchInput, runtimeContext?: SearchRuntimeContext): Promise<SearchOutput>;
 	/** Resolve the active raw-message manager. */
 	getRawMessageManager: typeof getRawMessageManager;
 	/**
@@ -157,6 +162,7 @@ export async function createMemoryStore(config: MemoryStoreConfig = {}): Promise
 }
 
 export type { MemoryStoreConfig };
+export type { SearchRuntimeContext } from "./search/applicability";
 export {
 	createRawMessageStore,
 	getRawMessageManager,
@@ -269,6 +275,7 @@ export type {
 	UnifiedSearchKnowledgeResult,
 	UnifiedSearchInsightsResult,
 	UnifiedSearchReasoningDeps,
+	SearchProviderApplicabilityInput,
 } from "./config";
 export type { RawMessage } from "./config";
 export {

--- a/packages/memory-store/src/search/applicability-fail-closed.test.ts
+++ b/packages/memory-store/src/search/applicability-fail-closed.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UnifiedSearchDeps } from "../config";
+import type { SearchRuntimeContext } from "./applicability";
+import { createUnifiedSearch } from "./unified-search";
+
+const builtIns = vi.hoisted(() => ({
+	chromaEnabled: false,
+	searchChroma: vi.fn(),
+	getRawMessageManager: vi.fn(),
+	searchSqliteSemantic: vi.fn(),
+	searchSqliteLexical: vi.fn(),
+}));
+
+vi.mock("../storage/chroma-memory-index", () => ({
+	isRawMessageChromaEnabled: () => builtIns.chromaEnabled,
+	searchRawMessagesWithChroma: builtIns.searchChroma,
+}));
+
+vi.mock("../storage/raw-message-store", () => ({
+	isRawMessageStorageAvailable: () => true,
+	getRawMessageManager: builtIns.getRawMessageManager,
+}));
+
+vi.mock("../storage/sqlite-raw-message-store", () => ({
+	lexicalSearchRawMessages: builtIns.searchSqliteLexical,
+}));
+
+const builtInHit = {
+	id: "legacy-raw",
+	content: "legacy unscoped raw memory",
+	similarity: 0.95,
+	metadata: {},
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	builtIns.chromaEnabled = false;
+	builtIns.searchChroma.mockResolvedValue([builtInHit]);
+	builtIns.searchSqliteSemantic.mockResolvedValue([builtInHit]);
+	builtIns.searchSqliteLexical.mockResolvedValue([builtInHit]);
+	builtIns.getRawMessageManager.mockResolvedValue({
+		searchMessagesSemantically: builtIns.searchSqliteSemantic,
+	});
+});
+
+function searchRaw(deps: UnifiedSearchDeps, runtimeContext?: SearchRuntimeContext) {
+	return createUnifiedSearch(deps).search(
+		{
+			userId: "u1",
+			query: "Alpha project details",
+			tiers: ["raw"],
+			sources: ["memory"],
+		},
+		runtimeContext,
+	);
+}
+
+function expectApplicabilityWarning(warnings: ReadonlyArray<{ code: string }>): void {
+	expect(warnings.filter((warning) => warning.code === "memory_applicability_not_enforced")).toHaveLength(1);
+}
+
+describe("built-in raw-message applicability fail-closed behaviour", () => {
+	it("does not query Chroma for a scoped search", async () => {
+		builtIns.chromaEnabled = true;
+
+		const output = await searchRaw({ embedQuery: async () => [0.1, 0.2] }, { applicabilityContexts: [] });
+
+		expect(output.results).toEqual([]);
+		expect(builtIns.searchChroma).not.toHaveBeenCalled();
+		expect(builtIns.getRawMessageManager).not.toHaveBeenCalled();
+		expectApplicabilityWarning(output.warnings);
+	});
+
+	it("does not query the built-in SQLite semantic source for a scoped search", async () => {
+		const output = await searchRaw(
+			{ embedQuery: async () => [0.1, 0.2] },
+			{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+		);
+
+		expect(output.results).toEqual([]);
+		expect(builtIns.getRawMessageManager).not.toHaveBeenCalled();
+		expect(builtIns.searchSqliteSemantic).not.toHaveBeenCalled();
+		expectApplicabilityWarning(output.warnings);
+	});
+
+	it("does not query the built-in SQLite lexical source for a scoped search", async () => {
+		const output = await searchRaw({}, { applicabilityContexts: [{ scope: "project", key: "project-a" }] });
+
+		expect(output.results).toEqual([]);
+		expect(builtIns.searchSqliteLexical).not.toHaveBeenCalled();
+		expectApplicabilityWarning(output.warnings);
+	});
+
+	it("does not fall back to SQLite when an applicability-aware lexical provider fails", async () => {
+		const output = await searchRaw(
+			{
+				searchRawMessagesLexical: async () => {
+					throw new Error("provider unavailable");
+				},
+				logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+			},
+			{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+		);
+
+		expect(output.results).toEqual([]);
+		expect(builtIns.searchSqliteLexical).not.toHaveBeenCalled();
+		expectApplicabilityWarning(output.warnings);
+	});
+
+	it("uses an applicability-aware ANN provider instead of enabled Chroma", async () => {
+		builtIns.chromaEnabled = true;
+		const searchRawMessagesAnn = vi.fn<NonNullable<UnifiedSearchDeps["searchRawMessagesAnn"]>>(async () => [
+			{ id: "scoped", content: "project A", similarity: 0.9, metadata: {} },
+		]);
+
+		const output = await searchRaw(
+			{ embedQuery: async () => [0.1, 0.2], searchRawMessagesAnn },
+			{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+		);
+
+		expect(output.results.map((result) => result.id)).toEqual(["scoped"]);
+		expect(searchRawMessagesAnn).toHaveBeenCalledTimes(1);
+		expect(builtIns.searchChroma).not.toHaveBeenCalled();
+		expect(output.warnings).not.toContainEqual(
+			expect.objectContaining({ code: "memory_applicability_not_enforced" }),
+		);
+	});
+
+	it("does not fall back to SQLite when an applicability-aware ANN provider returns no hits", async () => {
+		const output = await searchRaw(
+			{
+				embedQuery: async () => [0.1, 0.2],
+				searchRawMessagesAnn: async () => [],
+			},
+			{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+		);
+
+		expect(output.results).toEqual([]);
+		expect(builtIns.getRawMessageManager).not.toHaveBeenCalled();
+		expectApplicabilityWarning(output.warnings);
+	});
+
+	it("preserves legacy Chroma retrieval when no runtime context is supplied", async () => {
+		builtIns.chromaEnabled = true;
+
+		const output = await searchRaw({ embedQuery: async () => [0.1, 0.2] });
+
+		expect(output.results.map((result) => result.id)).toContain("legacy-raw");
+		expect(builtIns.searchChroma).toHaveBeenCalledTimes(1);
+		expect(output.warnings).not.toContainEqual(
+			expect.objectContaining({ code: "memory_applicability_not_enforced" }),
+		);
+	});
+
+	it("preserves legacy SQLite semantic and lexical fallbacks", async () => {
+		const semanticOutput = await searchRaw({ embedQuery: async () => [0.1, 0.2] });
+		const lexicalOutput = await searchRaw({});
+
+		expect(semanticOutput.results.map((result) => result.id)).toContain("legacy-raw");
+		expect(lexicalOutput.results.map((result) => result.id)).toContain("legacy-raw");
+		expect(builtIns.searchSqliteSemantic).toHaveBeenCalledTimes(1);
+		expect(builtIns.searchSqliteLexical).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/memory-store/src/search/applicability-propagation.test.ts
+++ b/packages/memory-store/src/search/applicability-propagation.test.ts
@@ -1,0 +1,298 @@
+import type { MemoryApplicabilityContext } from "@melandlabs/memory-consolidation";
+import { applicabilityMatchesTrustedContexts } from "@melandlabs/memory-consolidation/graph-retrieval";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { UnifiedSearchDeps, UnifiedSearchKnowledgeResult, UnifiedSearchReasoningDeps } from "../config";
+import type { IterativeRecallPlanner, IterativeRecallSearchRequest } from "./iterative-recall";
+import { createUnifiedSearch } from "./unified-search";
+
+vi.mock("../storage/chroma-memory-index", () => ({
+	isRawMessageChromaEnabled: () => false,
+	searchRawMessagesWithChroma: () => Promise.resolve([]),
+}));
+
+vi.mock("../storage/raw-message-store", () => ({
+	isRawMessageStorageAvailable: () => true,
+}));
+
+type ProviderName = "ann" | "lexical" | "entity" | "knowledge" | "insights" | "summaries";
+type ProviderCalls = Record<ProviderName, unknown[]>;
+
+function createProviderCalls(): ProviderCalls {
+	return {
+		ann: [],
+		lexical: [],
+		entity: [],
+		knowledge: [],
+		insights: [],
+		summaries: [],
+	};
+}
+
+function createRecordingDeps(
+	calls: ProviderCalls,
+	reasoning?: UnifiedSearchReasoningDeps,
+): UnifiedSearchDeps {
+	return {
+		embedQuery: async () => [0.1, 0.2],
+		searchRawMessagesAnn: async (input) => {
+			calls.ann.push(input);
+			return [{ id: "raw-ann", content: "ann", similarity: 0.9, metadata: {} }];
+		},
+		searchRawMessagesLexical: async (input) => {
+			calls.lexical.push(input);
+			return [{ id: "raw-lexical", content: "lexical", similarity: 0.8, metadata: {} }];
+		},
+		entitySearch: async (input) => {
+			calls.entity.push(input);
+			return [{ messageId: "raw-entity", label: "Alpha", score: 0.7 }];
+		},
+		searchKnowledge: async (input) => {
+			calls.knowledge.push(input);
+			return [
+				{
+					chunkId: "chunk-1",
+					documentId: "doc-1",
+					documentName: "Doc",
+					content: "knowledge",
+					similarity: 0.6,
+					chunkIndex: 0,
+				},
+			];
+		},
+		searchInsights: async (input) => {
+			calls.insights.push(input);
+			return [{ id: "insight-1", content: "insight", similarity: 0.5, metadata: {} }];
+		},
+		searchSummaries: async (input) => {
+			calls.summaries.push(input);
+			return [{ summaryId: "summary-1", summaryText: "summary" }];
+		},
+		reasoning,
+	};
+}
+
+function allProviderInputs(calls: ProviderCalls): Array<Record<string, unknown>> {
+	return Object.values(calls).flat() as Array<Record<string, unknown>>;
+}
+
+function expectRuntimeOnEveryCall(
+	calls: ProviderCalls,
+	contexts: readonly MemoryApplicabilityContext[],
+	applicabilityAt: number,
+): void {
+	const inputs = allProviderInputs(calls);
+	expect(inputs.length).toBeGreaterThan(0);
+	for (const input of inputs) {
+		expect(input.applicabilityContexts).toBe(contexts);
+		expect(input.applicabilityAt).toBe(applicabilityAt);
+	}
+}
+
+async function searchEveryTier(
+	deps: UnifiedSearchDeps,
+	runtimeContext?: { applicabilityContexts: readonly MemoryApplicabilityContext[] },
+	asOf?: string,
+): Promise<void> {
+	await createUnifiedSearch(deps).search(
+		{
+			userId: "u1",
+			query: "Alpha project details",
+			tiers: ["summary", "raw", "insight", "knowledge"],
+			sources: ["memory", "insights", "knowledge"],
+			asOf,
+		},
+		runtimeContext,
+	);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("search applicability propagation", () => {
+	it("forwards the same contexts and parsed asOf to all six retrieval providers", async () => {
+		const calls = createProviderCalls();
+		const contexts = [{ scope: "project" as const, key: "project-a" }] as const;
+		const asOf = "2026-01-15T00:00:00.000Z";
+
+		await searchEveryTier(createRecordingDeps(calls), { applicabilityContexts: contexts }, asOf);
+
+		for (const provider of Object.keys(calls) as ProviderName[]) {
+			expect(calls[provider], `${provider} provider was not called`).toHaveLength(1);
+		}
+		expectRuntimeOnEveryCall(calls, contexts, Date.parse(asOf));
+	});
+
+	it("does not add applicability fields to legacy provider inputs", async () => {
+		const calls = createProviderCalls();
+
+		await searchEveryTier(createRecordingDeps(calls), undefined, "not-a-timestamp");
+
+		for (const input of allProviderInputs(calls)) {
+			expect(input).not.toHaveProperty("applicabilityContexts");
+			expect(input).not.toHaveProperty("applicabilityAt");
+		}
+	});
+
+	it("captures one timestamp when asOf is omitted and shares it across all providers", async () => {
+		const calls = createProviderCalls();
+		const contexts: readonly MemoryApplicabilityContext[] = [];
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+
+		await searchEveryTier(createRecordingDeps(calls), { applicabilityContexts: contexts });
+
+		expect(now).toHaveBeenCalledTimes(1);
+		expectRuntimeOnEveryCall(calls, contexts, 1_800_000_000_000);
+	});
+
+	it("keeps applicability out of the query rewriter while inheriting it in every rewritten search", async () => {
+		const calls = createProviderCalls();
+		const rewriteInputs: unknown[] = [];
+		const reasoning: UnifiedSearchReasoningDeps = {
+			queryRewriter: {
+				rewrite: async (input) => {
+					rewriteInputs.push(input);
+					return [input.query, "Project Alpha history"];
+				},
+			},
+		};
+		const contexts = [{ scope: "project" as const, key: "project-a" }] as const;
+		const asOf = "2026-02-01T00:00:00.000Z";
+
+		await createUnifiedSearch(createRecordingDeps(calls, reasoning)).search(
+			{
+				userId: "u1",
+				query: "Alpha project details",
+				tiers: ["raw"],
+				sources: ["memory"],
+				reasoningStrategy: "rewrite",
+				asOf,
+			},
+			{ applicabilityContexts: contexts },
+		);
+
+		expect(rewriteInputs).toHaveLength(1);
+		expect(rewriteInputs[0]).not.toHaveProperty("applicabilityContexts");
+		expect(rewriteInputs[0]).not.toHaveProperty("applicabilityAt");
+		expect(calls.ann).toHaveLength(2);
+		expectRuntimeOnEveryCall(calls, contexts, Date.parse(asOf));
+	});
+
+	it.each(["iterative", "union"] as const)(
+		"keeps %s planner inputs unscoped and prevents executor requests from overriding runtime scope",
+		async (reasoningStrategy) => {
+			const calls = createProviderCalls();
+			const plannerInputs: unknown[] = [];
+			const planner: IterativeRecallPlanner = {
+				plan: async (input) => {
+					plannerInputs.push(input);
+					const candidates = await input.executor.search({
+						keywords: ["alpha"],
+						applicabilityContexts: [{ scope: "project", key: "project-b" }],
+						applicabilityAt: 0,
+					} as unknown as IterativeRecallSearchRequest);
+					return {
+						evidence: candidates.candidates,
+						stats: { iterations: 1, searches: 1, notes: 1 },
+					};
+				},
+			};
+			const contexts = [{ scope: "project" as const, key: "project-a" }] as const;
+			const asOf = "2026-03-01T00:00:00.000Z";
+
+			await createUnifiedSearch(createRecordingDeps(calls, { iterativePlanner: planner })).search(
+				{
+					userId: "u1",
+					query: "Alpha project details",
+					tiers: ["raw"],
+					sources: ["memory"],
+					reasoningStrategy,
+					asOf,
+				},
+				{ applicabilityContexts: contexts },
+			);
+
+			expect(plannerInputs).toHaveLength(1);
+			expect(plannerInputs[0]).not.toHaveProperty("applicabilityContexts");
+			expect(plannerInputs[0]).not.toHaveProperty("applicabilityAt");
+			expect(calls.ann.length).toBeGreaterThan(0);
+			expect(calls.lexical.length).toBeGreaterThan(0);
+			expectRuntimeOnEveryCall(calls, contexts, Date.parse(asOf));
+		},
+	);
+
+	it("keeps synthesis evidence inside the scope enforced by a contract-compliant provider", async () => {
+		const candidates: Array<UnifiedSearchKnowledgeResult & { applicability?: MemoryApplicabilityContext }> = [
+			{
+				chunkId: "global",
+				documentId: "doc-global",
+				documentName: "Global",
+				content: "global guidance",
+				similarity: 0.9,
+				chunkIndex: 0,
+				applicability: { scope: "global" },
+			},
+			{
+				chunkId: "project-a",
+				documentId: "doc-a",
+				documentName: "Project A",
+				content: "project A evidence",
+				similarity: 0.8,
+				chunkIndex: 0,
+				applicability: { scope: "project", key: "project-a" },
+			},
+			{
+				chunkId: "project-b",
+				documentId: "doc-b",
+				documentName: "Project B",
+				content: "project B confidential evidence",
+				similarity: 0.99,
+				chunkIndex: 0,
+				applicability: { scope: "project", key: "project-b" },
+			},
+		];
+		const synthesisPrompts: string[] = [];
+		const searchKnowledge: NonNullable<UnifiedSearchDeps["searchKnowledge"]> = async (input) => {
+			if (input.applicabilityContexts === undefined || input.applicabilityAt === undefined) {
+				throw new Error("trusted applicability context was not propagated");
+			}
+			const contexts = input.applicabilityContexts;
+			const applicabilityAt = input.applicabilityAt;
+			return candidates
+				.filter((candidate) =>
+					applicabilityMatchesTrustedContexts(candidate.applicability, contexts, applicabilityAt),
+				)
+				.map(({ applicability: _applicability, ...result }) => result);
+		};
+		const search = createUnifiedSearch({
+			searchKnowledge,
+			reasoning: {
+				complete: async (prompt) => {
+					synthesisPrompts.push(prompt);
+					return "Supported by [1] and [2].";
+				},
+			},
+		});
+
+		const output = await search.search(
+			{
+				userId: "u1",
+				query: "What applies to project A?",
+				tiers: ["knowledge"],
+				sources: ["knowledge"],
+				synthesize: true,
+				asOf: "2026-04-01T00:00:00.000Z",
+			},
+			{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+		);
+
+		expect(output.results.map((result) => result.id)).toEqual(["global", "project-a"]);
+		expect(output.evidence.map((evidence) => evidence.id)).toEqual(["global", "project-a"]);
+		expect(output.answer).toBe("Supported by [1] and [2].");
+		expect(synthesisPrompts).toHaveLength(1);
+		expect(synthesisPrompts[0]).toContain("global guidance");
+		expect(synthesisPrompts[0]).toContain("project A evidence");
+		expect(synthesisPrompts[0]).not.toContain("project B confidential evidence");
+	});
+});

--- a/packages/memory-store/src/search/applicability.test.ts
+++ b/packages/memory-store/src/search/applicability.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { type SearchRuntimeContext, resolveSearchRuntimeContext } from "./applicability";
+import { createUnifiedSearch } from "./unified-search";
+
+describe("resolveSearchRuntimeContext", () => {
+	it("preserves legacy behaviour when no runtime context is supplied", () => {
+		const now = vi.fn(() => 1_700_000_000_000);
+
+		expect(resolveSearchRuntimeContext({ asOf: "not-a-timestamp" }, undefined, now)).toBeUndefined();
+		expect(now).not.toHaveBeenCalled();
+	});
+
+	it("distinguishes an explicit empty context list and captures time once", () => {
+		const contexts = [] as const;
+		const now = vi.fn(() => 1_700_000_000_000);
+
+		const resolved = resolveSearchRuntimeContext(
+			{ asOf: undefined },
+			{ applicabilityContexts: contexts },
+			now,
+		);
+
+		expect(resolved).toEqual({ applicabilityContexts: [], applicabilityAt: 1_700_000_000_000 });
+		expect(resolved?.applicabilityContexts).toBe(contexts);
+		expect(now).toHaveBeenCalledTimes(1);
+	});
+
+	it("parses asOf once and preserves the supplied contexts by reference", () => {
+		const contexts = [{ scope: "project" as const, key: "project-a" }] as const;
+		const now = vi.fn(() => 1_800_000_000_000);
+		const asOf = "2026-01-15T00:00:00.000Z";
+
+		const resolved = resolveSearchRuntimeContext({ asOf }, { applicabilityContexts: contexts }, now);
+
+		expect(resolved?.applicabilityContexts).toBe(contexts);
+		expect(resolved?.applicabilityAt).toBe(Date.parse(asOf));
+		expect(now).not.toHaveBeenCalled();
+	});
+
+	it.each([{ scope: "project" }, { scope: "project", key: "" }, { scope: "project", key: "   " }])(
+		"rejects a keyless non-global context %#",
+		(context) => {
+			expect(() =>
+				resolveSearchRuntimeContext({}, { applicabilityContexts: [context] } as Parameters<
+					typeof resolveSearchRuntimeContext
+				>[1]),
+			).toThrow(/key must be non-empty/);
+		},
+	);
+
+	it("allows a global context without a key", () => {
+		expect(
+			resolveSearchRuntimeContext({}, { applicabilityContexts: [{ scope: "global" }] }, () => 123),
+		).toEqual({ applicabilityContexts: [{ scope: "global" }], applicabilityAt: 123 });
+	});
+
+	it.each([
+		[{ scope: "workspace", key: "w1" }],
+		[{ scope: "project", key: 42 }],
+		[{ scope: "project", key: "project-a", validFrom: Number.NaN }],
+		[{ scope: "project", key: "project-a", validUntil: Number.POSITIVE_INFINITY }],
+	])("rejects malformed applicability contexts %#", (applicabilityContexts) => {
+		expect(() =>
+			resolveSearchRuntimeContext({}, { applicabilityContexts } as unknown as Parameters<
+				typeof resolveSearchRuntimeContext
+			>[1]),
+		).toThrow(/memory-store search runtime context/);
+	});
+
+	it("rejects a missing applicabilityContexts array", () => {
+		expect(() =>
+			resolveSearchRuntimeContext({}, {} as Parameters<typeof resolveSearchRuntimeContext>[1]),
+		).toThrow(/applicabilityContexts must be an array/);
+	});
+
+	it("rejects an unparseable asOf only when runtime scoping is enabled", () => {
+		expect(() =>
+			resolveSearchRuntimeContext(
+				{ asOf: "not-a-timestamp" },
+				{ applicabilityContexts: [{ scope: "project", key: "project-a" }] },
+			),
+		).toThrow(/asOf must be a parseable timestamp/);
+
+		expect(resolveSearchRuntimeContext({ asOf: "not-a-timestamp" }, undefined)).toBeUndefined();
+	});
+});
+
+describe("search runtime boundary", () => {
+	it("rejects invalid trusted contexts before invoking a search provider", async () => {
+		const searchRawMessagesLexical = vi.fn(async () => []);
+		const search = createUnifiedSearch({ searchRawMessagesLexical });
+		const invalidRuntime = {
+			applicabilityContexts: [{ scope: "project" }],
+		} as unknown as SearchRuntimeContext;
+
+		await expect(search.search({ userId: "u1", query: "anything" }, invalidRuntime)).rejects.toThrow(
+			/key must be non-empty/,
+		);
+		expect(searchRawMessagesLexical).not.toHaveBeenCalled();
+	});
+});

--- a/packages/memory-store/src/search/applicability.ts
+++ b/packages/memory-store/src/search/applicability.ts
@@ -1,0 +1,102 @@
+import type { MemoryApplicabilityContext, MemoryApplicabilityScope } from "@melandlabs/memory-consolidation";
+
+import type { SearchInput } from "./utilities";
+
+const APPLICABILITY_SCOPES: ReadonlySet<MemoryApplicabilityScope> = new Set([
+	"global",
+	"task",
+	"conversation",
+	"channel",
+	"project",
+	"custom",
+]);
+
+/**
+ * Trusted, in-process context for one `search()` call. Hosts must derive these
+ * contexts from authenticated server-side state rather than public payloads.
+ * An explicit empty array requests global-only retrieval; omitting the runtime
+ * context preserves legacy unscoped behaviour.
+ */
+export interface SearchRuntimeContext {
+	applicabilityContexts: readonly MemoryApplicabilityContext[];
+}
+
+/** Validated context shared by every retrieval performed for one search. */
+export interface ResolvedSearchRuntimeContext {
+	applicabilityContexts: readonly MemoryApplicabilityContext[];
+	/** Epoch milliseconds, resolved exactly once at the search boundary. */
+	applicabilityAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidRuntimeContext(message: string): never {
+	throw new TypeError(`memory-store search runtime context: ${message}`);
+}
+
+function validateApplicabilityContext(value: unknown, index: number): void {
+	const path = `applicabilityContexts[${index}]`;
+	if (!isRecord(value)) {
+		invalidRuntimeContext(`${path} must be an object`);
+	}
+
+	const scope = value.scope;
+	if (typeof scope !== "string" || !APPLICABILITY_SCOPES.has(scope as MemoryApplicabilityScope)) {
+		invalidRuntimeContext(`${path}.scope is not supported`);
+	}
+
+	if (value.key !== undefined && typeof value.key !== "string") {
+		invalidRuntimeContext(`${path}.key must be a string when provided`);
+	}
+	if (scope !== "global" && (typeof value.key !== "string" || value.key.trim().length === 0)) {
+		invalidRuntimeContext(`${path}.key must be non-empty for scope "${scope}"`);
+	}
+
+	for (const field of ["validFrom", "validUntil"] as const) {
+		const boundary = value[field];
+		if (boundary !== undefined && (typeof boundary !== "number" || !Number.isFinite(boundary))) {
+			invalidRuntimeContext(`${path}.${field} must be a finite epoch-millisecond number`);
+		}
+	}
+}
+
+/**
+ * Validate and resolve the trusted runtime context before any retrieval or LLM
+ * callback is invoked. The applicability array is deliberately returned by
+ * reference so downstream providers can receive the host-supplied value
+ * unchanged.
+ */
+export function resolveSearchRuntimeContext(
+	input: Pick<SearchInput, "asOf">,
+	runtimeContext: SearchRuntimeContext | undefined,
+	now: () => number = Date.now,
+): ResolvedSearchRuntimeContext | undefined {
+	if (runtimeContext === undefined) {
+		return undefined;
+	}
+	if (!isRecord(runtimeContext) || !Array.isArray(runtimeContext.applicabilityContexts)) {
+		invalidRuntimeContext("applicabilityContexts must be an array");
+	}
+
+	for (const [index, context] of runtimeContext.applicabilityContexts.entries()) {
+		validateApplicabilityContext(context, index);
+	}
+
+	let applicabilityAt: number;
+	if (input.asOf === undefined) {
+		applicabilityAt = now();
+	} else {
+		const parsed = typeof input.asOf === "string" ? Date.parse(input.asOf) : Number.NaN;
+		if (!Number.isFinite(parsed)) {
+			invalidRuntimeContext("asOf must be a parseable timestamp when a runtime context is supplied");
+		}
+		applicabilityAt = parsed;
+	}
+
+	return {
+		applicabilityContexts: runtimeContext.applicabilityContexts,
+		applicabilityAt,
+	};
+}

--- a/packages/memory-store/src/search/gather-evidence.ts
+++ b/packages/memory-store/src/search/gather-evidence.ts
@@ -22,6 +22,7 @@
 
 import type { Peer } from "@melandlabs/contracts/peer";
 import type { MemorySummaryHit, UnifiedSearchDeps } from "../config";
+import type { ResolvedSearchRuntimeContext } from "./applicability";
 import { applyReranker } from "./reranker";
 import type {
 	SearchInput,
@@ -106,6 +107,7 @@ export async function gatherSummaries(
 	threshold: number,
 	logger: Pick<Console, "warn">,
 	peerPeers: ReadonlyArray<Peer>,
+	runtimeContext?: ResolvedSearchRuntimeContext,
 ): Promise<GatheredEvidence> {
 	if (typeof deps.searchSummaries !== "function") {
 		return { hits: [], warnings: [] };
@@ -126,6 +128,7 @@ export async function gatherSummaries(
 			threshold,
 			authToken: input.authToken,
 			...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
+			...(runtimeContext ?? {}),
 		});
 		const hits = rows.map(toSummaryResult);
 		return { hits, warnings: [] };

--- a/packages/memory-store/src/search/unified-search.ts
+++ b/packages/memory-store/src/search/unified-search.ts
@@ -6,7 +6,7 @@
  * dependencies via `UnifiedSearchDeps` so this module stays
  * framework-agnostic.
  *
- * The public entry point is `search(input)` — a single method. Set
+ * The public entry point is `search(input, runtimeContext?)` — a single method. Set
  * `synthesize: true` to opt into the LLM synthesis step.
  */
 
@@ -14,6 +14,11 @@ import type { Peer } from "@melandlabs/contracts/peer";
 import type { UnifiedSearchDeps } from "../config";
 import { isRawMessageChromaEnabled, searchRawMessagesWithChroma } from "../storage/chroma-memory-index";
 import { isRawMessageStorageAvailable } from "../storage/raw-message-store";
+import {
+	type ResolvedSearchRuntimeContext,
+	type SearchRuntimeContext,
+	resolveSearchRuntimeContext,
+} from "./applicability";
 import { type ApplyConsolidateInput, type ApplyConsolidateOutput, applyReflectedPlan } from "./apply-reflect";
 import { gatherSummaries, resolveSearchScopePeers, synthesizeAnswer } from "./gather-evidence";
 import type {
@@ -69,6 +74,7 @@ export type {
 	SearchTier,
 	SearchEvidence,
 } from "./utilities";
+export type { SearchRuntimeContext } from "./applicability";
 
 export {
 	clampUnifiedMemorySearchLimit,
@@ -89,9 +95,10 @@ export {
 export interface UnifiedSearch {
 	/**
 	 * Single unified read entry point. Set `synthesize: true` to opt into
-	 * LLM synthesis.
+	 * LLM synthesis. The optional second argument is trusted in-process
+	 * applicability context and is intentionally separate from `SearchInput`.
 	 */
-	search(input: SearchInput): Promise<SearchOutput>;
+	search(input: SearchInput, runtimeContext?: SearchRuntimeContext): Promise<SearchOutput>;
 	/**
 	 * @deprecated Use `search(input)` instead. Forwarding shim kept for
 	 * one release window.
@@ -151,6 +158,7 @@ async function runEntitySearchForQuery(
 	limit: number,
 	logger: Pick<Console, "warn">,
 	peerPeers: ReadonlyArray<Peer> = [],
+	runtimeContext?: ResolvedSearchRuntimeContext,
 ): Promise<UnifiedMemorySearchResult[]> {
 	if (typeof deps.entitySearch !== "function") {
 		return [];
@@ -171,6 +179,7 @@ async function runEntitySearchForQuery(
 						limit: Math.ceil(limit / filters.length),
 						botId,
 						...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
+						...(runtimeContext ?? {}),
 					}),
 				),
 			)
@@ -278,6 +287,18 @@ function filterByDateRange<T extends { metadata: Record<string, unknown> }>(
 	});
 }
 
+function warnApplicabilityNotEnforced(warnings: UnifiedMemorySearchWarning[]): void {
+	if (warnings.some((warning) => warning.code === "memory_applicability_not_enforced")) {
+		return;
+	}
+	warnings.push({
+		source: "memory",
+		code: "memory_applicability_not_enforced",
+		message:
+			"Built-in raw-message retrieval was skipped because it cannot enforce the supplied applicability context. Configure an applicability-aware raw-message provider.",
+	});
+}
+
 async function embedQueryVariant(
 	embedQuery: NonNullable<UnifiedSearchDeps["embedQuery"]>,
 	input: UnifiedMemorySearchInput,
@@ -297,12 +318,14 @@ async function runSemanticSearchForEmbedding(
 	limit: number,
 	threshold: number,
 	logger: Pick<Console, "log" | "warn">,
-	peerPeers: ReadonlyArray<Peer> = [],
+	peerPeers: ReadonlyArray<Peer>,
+	warnings: UnifiedMemorySearchWarning[],
+	runtimeContext?: ResolvedSearchRuntimeContext,
 ): Promise<UnifiedMemorySearchResult[]> {
 	const filters = input.botIds && input.botIds.length > 0 ? input.botIds.map((botId) => ({ botId })) : [{}];
 	let semantic: UnifiedMemorySearchResult[] = [];
 
-	if (isRawMessageChromaEnabled()) {
+	if (runtimeContext === undefined && isRawMessageChromaEnabled()) {
 		try {
 			semantic = (
 				await Promise.all(
@@ -345,6 +368,7 @@ async function runSemanticSearchForEmbedding(
 						botId: "botId" in filter ? filter.botId : undefined,
 						...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 						...(factTypes ? { factTypes } : {}),
+						...(runtimeContext ?? {}),
 					}),
 				),
 			)
@@ -355,6 +379,10 @@ async function runSemanticSearchForEmbedding(
 	}
 
 	if (semantic.length === 0) {
+		if (runtimeContext !== undefined) {
+			warnApplicabilityNotEnforced(warnings);
+			return [];
+		}
 		try {
 			const { getRawMessageManager } = await import("../storage/raw-message-store");
 			const manager = await getRawMessageManager();
@@ -425,7 +453,9 @@ async function runLexicalSearchForKeywords(
 	keywords: string[],
 	limit: number,
 	logger: Pick<Console, "warn">,
-	peerPeers: ReadonlyArray<Peer> = [],
+	peerPeers: ReadonlyArray<Peer>,
+	warnings: UnifiedMemorySearchWarning[],
+	runtimeContext?: ResolvedSearchRuntimeContext,
 ): Promise<UnifiedMemorySearchResult[]> {
 	if (keywords.length === 0) {
 		return [];
@@ -446,6 +476,7 @@ async function runLexicalSearchForKeywords(
 							botId,
 							...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 							...(factTypes ? { factTypes } : {}),
+							...(runtimeContext ?? {}),
 						}),
 					),
 				)
@@ -459,6 +490,10 @@ async function runLexicalSearchForKeywords(
 		} catch (error) {
 			logger.warn?.("[memory-store] lexical memory search failed:", error);
 		}
+	}
+	if (runtimeContext !== undefined) {
+		warnApplicabilityNotEnforced(warnings);
+		return [];
 	}
 
 	try {
@@ -569,6 +604,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 		reasoningStrategy: UnifiedMemoryReasoningStrategy = "none",
 		reasoningInfo?: UnifiedMemoryReasoningInfo,
 		peerPeers: ReadonlyArray<Peer> = [],
+		runtimeContext?: ResolvedSearchRuntimeContext,
 	): Promise<MemorySubQueries> {
 		if (
 			(reasoningStrategy === "iterative" || reasoningStrategy === "union") &&
@@ -620,6 +656,8 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 							limit,
 							logger,
 							peerPeers,
+							warnings,
+							runtimeContext,
 						);
 
 						let semanticHits: UnifiedMemorySearchResult[] = [];
@@ -635,6 +673,8 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 									threshold,
 									logger,
 									peerPeers,
+									warnings,
+									runtimeContext,
 								);
 							} catch (error) {
 								logger.warn?.(
@@ -695,7 +735,16 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 
 			const keywords = deriveLexicalKeywords(input.query);
 			const lexical = filterByDateRange(
-				await runLexicalSearchForKeywords(deps, input, keywords, limit, logger, peerPeers),
+				await runLexicalSearchForKeywords(
+					deps,
+					input,
+					keywords,
+					limit,
+					logger,
+					peerPeers,
+					warnings,
+					runtimeContext,
+				),
 				input.dateFrom,
 				input.dateTo,
 			);
@@ -733,7 +782,17 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 				);
 				const lists = await Promise.all(
 					embeddings.map((embedding) =>
-						runSemanticSearchForEmbedding(deps, input, embedding, limit, threshold, logger, peerPeers),
+						runSemanticSearchForEmbedding(
+							deps,
+							input,
+							embedding,
+							limit,
+							threshold,
+							logger,
+							peerPeers,
+							warnings,
+							runtimeContext,
+						),
 					),
 				);
 				semantic = mergeByMaxScore(lists);
@@ -759,6 +818,8 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 				threshold,
 				logger,
 				peerPeers,
+				warnings,
+				runtimeContext,
 			);
 		}
 
@@ -785,6 +846,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 									botId,
 									...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 									...(factTypes ? { factTypes } : {}),
+									...(runtimeContext ?? {}),
 								}),
 							),
 						)
@@ -821,7 +883,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 		let entity: UnifiedMemorySearchResult[] | undefined;
 		if (typeof deps.entitySearch === "function") {
 			entity = filterByDateRange(
-				await runEntitySearchForQuery(deps, input, limit, logger, peerPeers),
+				await runEntitySearchForQuery(deps, input, limit, logger, peerPeers, runtimeContext),
 				input.dateFrom,
 				input.dateTo,
 			);
@@ -899,7 +961,10 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 		return out;
 	}
 
-	async function searchUnifiedMemory(input: UnifiedMemorySearchInput): Promise<UnifiedMemorySearchOutput> {
+	async function searchUnifiedMemoryWithRuntime(
+		input: UnifiedMemorySearchInput,
+		runtimeContext?: ResolvedSearchRuntimeContext,
+	): Promise<UnifiedMemorySearchOutput> {
 		const query = input.query.trim();
 		const sources = normalizeUnifiedMemorySearchSources(input.sources);
 		const limit = clampUnifiedMemorySearchLimit(input.limit);
@@ -964,6 +1029,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 						reasoningStrategy,
 						reasoningInfo,
 						peerPeers,
+						runtimeContext,
 					);
 				} catch (error) {
 					logger.warn?.("[memory-store] memory source failed:", error);
@@ -994,6 +1060,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 					includeArchived: input.includeArchivedInsights,
 					authToken: input.authToken,
 					...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
+					...(runtimeContext ?? {}),
 				});
 				for (const hit of hits) {
 					insightHits.push({
@@ -1030,6 +1097,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 					},
 					authToken: input.authToken,
 					...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
+					...(runtimeContext ?? {}),
 				});
 				for (const hit of hits) {
 					knowledgeHits.push(toKnowledgeResult(hit));
@@ -1073,6 +1141,10 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 		return output;
 	}
 
+	async function searchUnifiedMemory(input: UnifiedMemorySearchInput): Promise<UnifiedMemorySearchOutput> {
+		return searchUnifiedMemoryWithRuntime(input);
+	}
+
 	/**
 	 * @deprecated Use `search({ ...input, sources: ["memory"] })` and
 	 * read `.results` instead. Thin shim around `searchUnifiedMemory`.
@@ -1108,7 +1180,10 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 	// tiers surface in the synthesis prompt. Read-only callers that don't
 	// ask for synthesis skip the summary gather entirely.
 
-	async function search(input: SearchInput): Promise<SearchOutput> {
+	async function searchWithResolvedRuntime(
+		input: SearchInput,
+		runtimeContext: ResolvedSearchRuntimeContext | undefined,
+	): Promise<SearchOutput> {
 		const query = input.query.trim();
 		const wantsSynthesis =
 			typeof input.synthesize === "boolean"
@@ -1173,10 +1248,13 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 							...(wantsInsightTier ? (["insights"] as const) : []),
 							...(wantsKnowledgeTier ? (["knowledge"] as const) : []),
 						];
-			const unified = await searchUnifiedMemory({
-				...searchInputToUnified(input),
-				sources: inferredSources.length > 0 ? inferredSources : undefined,
-			});
+			const unified = await searchUnifiedMemoryWithRuntime(
+				{
+					...searchInputToUnified(input),
+					sources: inferredSources.length > 0 ? inferredSources : undefined,
+				},
+				runtimeContext,
+			);
 			unifiedHits = unified.results;
 			sources = unified.sources;
 			unifiedReasoning = unified.reasoning;
@@ -1194,6 +1272,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 				threshold,
 				logger,
 				peerScope.peers,
+				runtimeContext,
 			);
 			warnings.push(...summaryBucket.warnings);
 			summaryHits = summaryBucket.hits;
@@ -1250,6 +1329,11 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 		base.answer = answer;
 		base.warnings = [...base.warnings, ...synthWarnings];
 		return base;
+	}
+
+	async function search(input: SearchInput, runtimeContext?: SearchRuntimeContext): Promise<SearchOutput> {
+		const resolvedRuntime = resolveSearchRuntimeContext(input, runtimeContext);
+		return searchWithResolvedRuntime(input, resolvedRuntime);
 	}
 
 	// ─── Deprecated shims ─────────────────────────────────────────────────────

--- a/packages/memory-store/src/transport-applicability.test.ts
+++ b/packages/memory-store/src/transport-applicability.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UnifiedSearchDeps } from "./config";
+import { startHttpServer } from "./http";
+import { startMcpServer } from "./mcp";
+
+interface McpRegistration {
+	config: { inputSchema?: Record<string, unknown> };
+	handler: (args: unknown) => Promise<unknown>;
+}
+
+const transportHarness = vi.hoisted(() => ({
+	httpFetch: undefined as ((request: Request) => Promise<Response>) | undefined,
+	mcpTools: new Map<string, McpRegistration>(),
+	closeRawStore: vi.fn(async () => undefined),
+}));
+
+vi.mock("@hono/node-server", () => ({
+	serve: vi.fn((options: { fetch: (request: Request) => Promise<Response> }) => {
+		transportHarness.httpFetch = options.fetch;
+		return { close: (done: () => void) => done() };
+	}),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+	McpServer: class {
+		tool(): void {}
+
+		registerTool(name: string, config: McpRegistration["config"], handler: McpRegistration["handler"]): void {
+			transportHarness.mcpTools.set(name, { config, handler });
+		}
+
+		async connect(): Promise<void> {}
+	},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+	StdioServerTransport: class {},
+}));
+
+vi.mock("@melandlabs/sqlite", () => ({
+	getSQLiteVsaStore: vi.fn(async () => ({})),
+	closeSQLiteVsaStore: vi.fn(async () => undefined),
+}));
+
+vi.mock("@melandlabs/okf/http", () => ({
+	registerOkfRoutes: vi.fn(),
+}));
+
+vi.mock("@melandlabs/okf/mcp", () => ({
+	registerOkfTools: vi.fn(),
+}));
+
+vi.mock("./storage/chroma-memory-index", () => ({
+	isRawMessageChromaEnabled: () => false,
+	searchRawMessagesWithChroma: vi.fn(async () => []),
+	upsertRawMessagesToChroma: vi.fn(async () => undefined),
+}));
+
+vi.mock("./storage/raw-message-store", () => ({
+	isRawMessageStorageAvailable: () => false,
+	createRawMessageStore: vi.fn(() => ({
+		getManager: vi.fn(async () => ({})),
+		close: transportHarness.closeRawStore,
+	})),
+}));
+
+vi.mock("./storage/sqlite-raw-message-store", () => ({
+	resolveSQLiteRawMessageDbPath: vi.fn(() => "memory-test.db"),
+	lexicalSearchRawMessages: vi.fn(async () => []),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	transportHarness.httpFetch = undefined;
+	transportHarness.mcpTools.clear();
+});
+
+function createKnowledgeRecorder(calls: unknown[]): NonNullable<UnifiedSearchDeps["searchKnowledge"]> {
+	return async (input) => {
+		calls.push(input);
+		return [];
+	};
+}
+
+const hostileApplicabilityPayload = {
+	applicabilityContexts: [{ scope: "project", key: "attacker-selected-project" }],
+	applicabilityAt: 0,
+};
+
+describe("public transport applicability boundary", () => {
+	it("ignores applicability fields in an HTTP /v1/search body", async () => {
+		const calls: unknown[] = [];
+		const server = await startHttpServer({
+			port: 0,
+			unified: { searchKnowledge: createKnowledgeRecorder(calls) },
+		});
+		const fetch = transportHarness.httpFetch;
+		expect(fetch).toBeTypeOf("function");
+
+		const response = await fetch?.(
+			new Request("http://127.0.0.1/v1/search", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					userId: "u1",
+					query: "project status",
+					tiers: ["knowledge"],
+					sources: ["knowledge"],
+					...hostileApplicabilityPayload,
+				}),
+			}),
+		);
+
+		expect(response?.status).toBe(200);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).not.toHaveProperty("applicabilityContexts");
+		expect(calls[0]).not.toHaveProperty("applicabilityAt");
+		await server.stop();
+	});
+
+	it("omits applicability from the MCP schema and ignores forged handler arguments", async () => {
+		const calls: unknown[] = [];
+		await startMcpServer({
+			unified: { searchKnowledge: createKnowledgeRecorder(calls) },
+		});
+		const registration = transportHarness.mcpTools.get("memory.search");
+
+		expect(registration).toBeDefined();
+		expect(registration?.config.inputSchema).not.toHaveProperty("applicabilityContexts");
+		expect(registration?.config.inputSchema).not.toHaveProperty("applicabilityAt");
+		await registration?.handler({
+			userId: "u1",
+			query: "project status",
+			tiers: ["knowledge"],
+			sources: ["knowledge"],
+			...hostileApplicabilityPayload,
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).not.toHaveProperty("applicabilityContexts");
+		expect(calls[0]).not.toHaveProperty("applicabilityAt");
+	});
+});


### PR DESCRIPTION
## Summary

- add a trusted in-process `SearchRuntimeContext` as the second argument to `store.search()`
- validate applicability contexts and resolve `SearchInput.asOf` once at the search boundary
- propagate the same contexts and timestamp to all unified retrieval providers
- align graph retrieval with the shared exact-match and validity-window contract
- fail closed when built-in raw-message sources cannot enforce applicability
- keep trusted applicability fields out of the public HTTP and MCP schemas

## What changed

`store.search()` now distinguishes between:

- no runtime context: preserve existing unscoped behavior
- `{ applicabilityContexts: [] }`: explicit global-only retrieval
- non-empty contexts: global memories plus exact scope/key matches

When a runtime context is supplied, `memory-store` validates it before retrieval and resolves one `applicabilityAt` timestamp for the entire search.

The same context and timestamp are forwarded to:

- raw-message ANN and lexical providers
- entity search
- knowledge search
- insight search
- summary search

This propagation also applies to searches triggered by the `rewrite`, `iterative`, and `union` reasoning strategies. Applicability data is not exposed to the query rewriter or iterative planner, so those callbacks cannot override the trusted scope.

`DefaultGraphAwareRetriever` now reuses `applicabilityMatchesTrustedContexts`, providing consistent behavior for global memories, exact scope/key matching, multiple contexts, and validity windows.

Built-in Chroma and SQLite raw-message sources cannot currently enforce applicability. Scoped searches therefore skip those sources and return a structured `memory_applicability_not_enforced` warning instead of returning potentially unscoped records.

The HTTP `/v1/search` endpoint and MCP `memory.search` tool remain unchanged and do not accept or forward trusted applicability fields.

## Compatibility

Existing callers that use `store.search(input)` are unaffected. Existing provider inputs also remain unchanged when no runtime context is supplied.

## Testing

- package builds passed
- full workspace typecheck passed
- `memory-consolidation`: 107 tests passed
- applicability-focused `memory-store`: 31 tests passed
- changed TypeScript files passed Biome checks
- changeset validation passed
- lockfile regeneration produced no diff
- `git diff --cached --check` passed

## Release metadata

- `@melandlabs/memory-store`: minor
- `@melandlabs/memory-consolidation`: patch

Closes #30