### PR TITLE
feat(benchmark): complete LongMemEval evidence chain and report

### DIFF
--- a/benchmark/longmemeval/.env.example
+++ b/benchmark/longmemeval/.env.example
@@ -8,3 +8,9 @@ ANSWER_MODEL=MiniMax-M3-highspeed
 
 # Judge LLM (OpenRouter) — used by the LLM judge in metrics.ts
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_ANSWER_MODEL=deepseek/deepseek-v4-flash-0731
+OPENROUTER_JUDGE_MODEL=qwen/qwen3.8-flash
+
+# Retrieval/evidence controls
+LONGMEMEVAL_TOP_K=8
+# LONGMEMEVAL_CHECKPOINT_DIR=checkpoints/longmemeval

--- a/benchmark/longmemeval/.gitignore
+++ b/benchmark/longmemeval/.gitignore
@@ -2,3 +2,5 @@
 results.json
 results_sample.json
 checkpoints/
+dataset/*.json
+runtime/

--- a/benchmark/longmemeval/README.md
+++ b/benchmark/longmemeval/README.md
@@ -48,6 +48,18 @@ opencontext http
 # → serves http://127.0.0.1:7421, no auth
 ```
 
+On Windows, after building the workspace dependencies, the bundled launcher
+starts the same local SQLite + dense/FTS + local-reranker configuration in a
+new timestamped database and writes its PID/database/log metadata under the
+ignored `runtime/` directory:
+
+```powershell
+pnpm --filter @melandlabs/ai-rag build
+pnpm --filter @melandlabs/memory-store build
+pnpm --filter @melandlabs/opencontext build
+./benchmark/longmemeval/start-daemon.ps1
+```
+
 Edit `.env` to add your API keys:
 
 ```env
@@ -58,6 +70,9 @@ ANSWER_MODEL=MiniMax-M3-highspeed
 
 # Judge LLM (OpenRouter); also the answerer fallback if ANTHROPIC_AUTH_TOKEN is unset
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_ANSWER_MODEL=deepseek/deepseek-v4-flash-0731
+OPENROUTER_JUDGE_MODEL=qwen/qwen3.8-flash
+LONGMEMEVAL_TOP_K=8
 ```
 
 ## Dataset Download
@@ -83,7 +98,8 @@ pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json --quick
 pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json --samples qid1,qid2,qid3
 
 # Save results to file
-pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json --output results.json
+pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json \
+  --output results/longmemeval.json --no-resume
 ```
 
 ### CLI Options
@@ -97,6 +113,12 @@ pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json --output results.
 | `--port`      | `-p`  | OpenContext daemon port (env: `OPENCONTEXT_PORT` / `OPENCONTEXT_URL`) | 7421 |
 | `--resume`    |       | Reuse completed checkpoints for the same models | true    |
 | `--no-resume` |       | Ignore checkpoints and run every selected entry | false   |
+| `--preflight-only` |  | Validate readiness without ingest/model calls | false |
+
+`LONGMEMEVAL_TOP_K` controls the final number of daemon-ranked hits passed to
+the answerer (default 8, maximum 50). It does not configure chunking, candidate
+generation, channel fusion, or reranking; those remain daemon-owned. Set
+`LONGMEMEVAL_CHECKPOINT_DIR` to isolate checkpoints for a specific run.
 
 Before ingest or model calls, the CLI checks the dataset and selected entries,
 daemon, credentials, output/checkpoint paths, and arguments. It reports all
@@ -114,11 +136,39 @@ The benchmark outputs:
 - **Per-type metrics** - F1, BLEU-1, BLEU-4 scores by question type
 - **Per-question predictions** - Individual question results
 - **Token usage** - Real provider usage when available; otherwise `null`
-- **Run manifest** - Git commit, dataset identity, models, retrieval top-k,
-  selection parameters, resume mode, and wall-clock time
+- **Run manifest** - Git commit and dirty/status evidence, full dataset identity
+  (including SHA-256), models, retrieval top-k, selection parameters, resume
+  mode, and wall-clock time
+- **Question trace JSONL** - query, final ranked Top-K with full content,
+  semantic/lexical/hybrid candidates, fused-before-rerank order, reranker
+  identity/timing, answer and judge prompts/responses, token usage, and failure stage
+- **Session ingest JSONL** - deterministic raw-message/session mapping, content
+  hashes, batch status, latency, warnings, and errors
+- **Retrieval diagnostics** - answer-session Recall@K, Hit@K, MRR,
+  Precision@K, dataset-source coverage, and candidate-channel recall
 
 With `--output results.json`, the manifest is written to
-`results.json.manifest.json`. Without `--output`, it is written under `results/`.
+`results.json.manifest.json`, question traces to `results.trace.jsonl`, and
+session ingestion evidence to `results.sessions.jsonl`. Without `--output`, the
+run manifest is still written under `results/`, but the two diagnostic JSONL
+artifacts are not emitted.
+
+The benchmark maps each upstream LongMemEval session to exactly one
+`RawMessage`. The daemon owns all child chunking, embedding, indexing,
+retrieval, fusion, and reranking. The benchmark only preserves source session
+IDs for provenance, calls `/v1/search`, passes the daemon's final Top-K results
+to the existing answer prompt, and scores the answer.
+
+For a formal run, start the daemon with a fresh database and use
+`--no-resume`. A successful local smoke test or a resumed checkpoint set is not
+a comparable full benchmark result.
+
+Readiness check without paid model calls:
+
+```bash
+pnpm benchmark -- --dataset dataset/longmemeval_s_cleaned.json \
+  --output results/longmemeval.json --no-resume --preflight-only
+```
 
 ### Metrics
 

--- a/benchmark/longmemeval/docs/longmemeval-v1-test-report.md
+++ b/benchmark/longmemeval/docs/longmemeval-v1-test-report.md
@@ -1,0 +1,127 @@
+# LongMemEval V1 OpenContext Evaluation Report
+
+- Report version: v1
+- Status: completed, 500 / 500 Answerer-and-Judge records persisted; no final execution errors
+- Dataset: `longmemeval_s_cleaned.json` (500 questions)
+- Result: [longmemeval-opencontext-v1.json](../results/longmemeval-opencontext-v1.json)
+- Run manifest: [longmemeval-opencontext-v1.json.manifest.json](../results/longmemeval-opencontext-v1.json.manifest.json)
+- Question trace: [longmemeval-opencontext-v1.trace.jsonl](../results/longmemeval-opencontext-v1.trace.jsonl)
+- Session-ingest trace: [longmemeval-opencontext-v1.sessions.jsonl](../results/longmemeval-opencontext-v1.sessions.jsonl)
+
+> `results/`, checkpoints, runtime databases, and model caches are excluded by `.gitignore`. This report is the committable summary; retain the linked raw artifacts for response-, source-, and trace-level audit. It intentionally does not create a separate question index.
+
+## 1. Purpose and scope
+
+This report records the completed OpenContext LongMemEval run. For each dataset question, the harness maps each source session to one `RawMessage`, gives it to the local OpenContext daemon for daemon-owned chunking, indexing, retrieval, fusion, and reranking, then supplies the daemon's final Top-8 results to the benchmark Answerer prompt. The benchmark judges that answer with an LLM and records retrieval and ingest evidence.
+
+The result is an end-to-end diagnostic, not a pure retrieval score: it includes the daemon's retrieval behavior, the supplied context, the Answerer model, and the Judge model. It is also **not** an AML/official-leaderboard LongMemEval score: this directory uses OpenContext's custom F1/BLEU metrics and custom LLM-judge prompt rather than the vendored AML pipeline.
+
+## 2. System and evaluation configuration
+
+| Item | Configuration |
+|---|---|
+| Dataset | `dataset/longmemeval_s_cleaned.json` |
+| Dataset size / SHA-256 | 277,383,467 bytes / `d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442` |
+| Questions | 500 |
+| Answerer | `openrouter:deepseek/deepseek-v4-flash-0731` |
+| Judge | `openrouter:qwen/qwen3.8-flash` |
+| Store | isolated local `sqlite-vec` daemon, with SQLite lexical search available |
+| Embedding | local `Xenova/all-MiniLM-L6-v2`, 384 dimensions |
+| Reranker | local `Xenova/ms-marco-MiniLM-L-6-v2` |
+| Parent record | one complete LongMemEval session per `RawMessage` |
+| Child chunking | daemon-owned, roughly 400 estimated tokens with 80-token overlap |
+| Retrieval | daemon-default final Top-8 |
+| Trace schema | `1.0` |
+| Manifest commit | `554238ad07bf1768e90a6cd0777471140ca431d1` |
+
+The manifest records `resume: true` and `git_dirty: true`. Completed checkpoints—including judged incorrect answers—were reused, while execution-error checkpoints were retried until no errors remained. This is a complete end-to-end artifact, but it is not a clean fresh-database, `--no-resume` baseline and should not be used for a formal version-to-version or leaderboard comparison.
+
+During recovery, the harness found that a small number of dataset haystacks repeat a `session_id` within the same question. The raw-message mapping now appends the session index only for duplicate occurrences; ordinary IDs remain stable. This prevents two different sessions from sharing a daemon message ID and merging their chunks. The final session trace records the corrected mapping.
+
+## 3. Evidence completeness and execution
+
+| Metric | Result |
+|---|---:|
+| Scheduled questions / persisted predictions | 500 / 500 |
+| Completed Answerer + Judge records | 500 / 500 |
+| Final execution errors | 0 / 500 (0.00%) |
+| Question traces | 500; 500 unique question IDs |
+| Retrieval, Answerer, and Judge traces present | 500 / 500 each |
+| Session-ingest records | 23,867 |
+| Final session-ingest errors | 0 |
+| Recorded prompt tokens | 3,982,026 |
+| Recorded completion tokens | 782,427 |
+| Recorded total tokens | 4,764,453 |
+| Mean recorded total tokens / question | 9,529 |
+
+Recorded token totals reflect completed provider responses represented in the final checkpoints. Failed attempts during the recovery process can have provider-side usage that is not included, so these values are not a billing total.
+
+## 4. Overall result
+
+All scheduled records completed, so the all-record and completed-only views are identical.
+
+| Metric | Result |
+|---|---:|
+| LLM-judge accuracy | 241 / 500 (48.20%) |
+| Mean token F1 | 0.1143 |
+| Mean BLEU-1 | 0.0820 |
+| Mean BLEU-4 | 0.0059 |
+
+The judge accuracy is the primary end-to-end outcome for this harness. F1 and BLEU provide lexical overlap diagnostics, but they should not be interpreted as substitutes for the LLM-judge result.
+
+## 5. Results by question type
+
+| Question type | Questions | LLM-judge accuracy | Mean F1 | Mean BLEU-1 |
+|---|---:|---:|---:|---:|
+| `single-session-user` | 70 | 46 / 70 (65.71%) | 0.1464 | 0.1153 |
+| `multi-session` | 133 | 42 / 133 (31.58%) | 0.0532 | 0.0406 |
+| `single-session-preference` | 30 | 14 / 30 (46.67%) | 0.1417 | 0.0945 |
+| `temporal-reasoning` | 133 | 46 / 133 (34.59%) | 0.1258 | 0.0783 |
+| `knowledge-update` | 78 | 41 / 78 (52.56%) | 0.0982 | 0.0681 |
+| `single-session-assistant` | 56 | 52 / 56 (92.86%) | 0.1995 | 0.1597 |
+
+`single-session-assistant` is the strongest category. `multi-session` and `temporal-reasoning` are substantially weaker, so any next iteration should focus on multi-evidence selection and temporal context use rather than treating the overall score as a single undifferentiated retrieval failure.
+
+## 6. Retrieval evidence
+
+All 500 questions have dataset answer-session references and pre-merge retrieval diagnostics. The following metrics are session-level: a retrieved result is relevant when its source session ID matches an official `answer_session_id`.
+
+| Metric | Result |
+|---|---:|
+| Retrieval-applicable questions | 500 / 500 |
+| Dataset source coverage | 1.0000 |
+| Pre-merge diagnostics available | 500 / 500 |
+| Semantic candidate answer-session recall | 0.7938 |
+| Lexical candidate answer-session recall | 0.9889 |
+| Final answer-session recall@8 | 0.9123 |
+| Hit@8 | 0.9640 |
+| All answer sessions retrieved@8 | 0.8500 |
+| Precision@8 | 0.2155 |
+| MRR | 0.8960 |
+
+The trace includes the final retrieved sessions plus semantic, lexical, hybrid/entity, fused-before-rerank, and reranker evidence where the daemon exposed those channels. The `hybrid` diagnostic channel's mean recall is zero in this artifact; this denotes no separately surfaced hybrid channel, not proof that the daemon omitted its own fusion path. The result should be interpreted from the observed final Top-8 evidence and the recorded channel fields rather than from a run label alone.
+
+## 7. End-to-end failure analysis
+
+The `failure_stage` label is an evidence classification for non-passing records, not a causal proof about any one subsystem.
+
+| Failure stage | Count |
+|---|---:|
+| `none` (judge-correct) | 241 |
+| `context_present_answer_failed` | 192 |
+| `retrieval_miss` | 18 |
+| `retrieval_partial` | 49 |
+| Execution/provider errors | 0 |
+
+Of 259 non-passing records, 67 have a final retrieval miss or only partial answer-session coverage, while 192 have all required answer sessions represented in final context but still fail the end-to-end judge. This supports investigating answer construction, prompt following, temporal reasoning, and multi-session synthesis in addition to retrieval coverage. It does **not** prove that the remaining 192 failures were caused only by the Answerer: judging and evidence quality still remain part of the measurement.
+
+## 8. Artifact boundaries and follow-up
+
+This artifact proves that every scheduled question reached a terminal, judged record with session-ingest, retrieval, Answerer, and Judge evidence. It does not prove a clean-baseline comparison because it used a dirty worktree and resume semantics.
+
+The narrow next steps are:
+
+1. Run a fresh database with `--no-resume` and a recorded clean commit or explicit patch identity before comparing systems or publishing a baseline.
+2. Analyze the 192 `context_present_answer_failed` records by question type and prompt/evidence sufficiency, especially temporal and multi-session questions.
+3. Improve final Top-8 coverage selection for the 67 retrieval-miss/partial records, preserving the daemon-owned ingestion and retrieval boundary.
+4. Use the AML-local path separately if an AML-comparable LongMemEval score is required; do not conflate it with this custom harness result.

--- a/benchmark/longmemeval/src/dataset.ts
+++ b/benchmark/longmemeval/src/dataset.ts
@@ -5,16 +5,88 @@
 import { readFile } from "node:fs/promises";
 import type { LongMemEvalEntry } from "./types";
 
+const QUESTION_TYPES = new Set([
+	"single-session-user",
+	"single-session-preference",
+	"single-session-assistant",
+	"multi-session",
+	"temporal-reasoning",
+	"knowledge-update",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateEntry(value: unknown, index: number): asserts value is LongMemEvalEntry {
+	if (!isRecord(value)) throw new Error(`entry ${index} must be an object`);
+	for (const field of ["question_id", "question_type", "question", "question_date"] as const) {
+		if (typeof value[field] !== "string" || value[field].length === 0) {
+			throw new Error(`entry ${index} has invalid ${field}`);
+		}
+	}
+	if (!QUESTION_TYPES.has(value.question_type as string)) {
+		throw new Error(`entry ${index} has unknown question_type: ${value.question_type}`);
+	}
+	if (typeof value.answer !== "string" && typeof value.answer !== "number") {
+		throw new Error(`entry ${index} has invalid answer`);
+	}
+	const answerSessionIds = value.answer_session_ids;
+	const haystackDates = value.haystack_dates;
+	const haystackSessionIds = value.haystack_session_ids;
+	if (!Array.isArray(answerSessionIds) || !answerSessionIds.every((item) => typeof item === "string"))
+		throw new Error(`entry ${index} has invalid answer_session_ids`);
+	if (!Array.isArray(haystackDates) || !haystackDates.every((item) => typeof item === "string"))
+		throw new Error(`entry ${index} has invalid haystack_dates`);
+	if (!Array.isArray(haystackSessionIds) || !haystackSessionIds.every((item) => typeof item === "string"))
+		throw new Error(`entry ${index} has invalid haystack_session_ids`);
+	if (!Array.isArray(value.haystack_sessions)) {
+		throw new Error(`entry ${index} has invalid haystack_sessions`);
+	}
+	if (
+		value.haystack_sessions.length !== haystackSessionIds.length ||
+		value.haystack_sessions.length !== haystackDates.length
+	) {
+		throw new Error(`entry ${index} has misaligned haystack session arrays`);
+	}
+	for (const [sessionIndex, session] of value.haystack_sessions.entries()) {
+		if (!Array.isArray(session)) throw new Error(`entry ${index} session ${sessionIndex} is not an array`);
+		for (const [turnIndex, turn] of session.entries()) {
+			if (
+				!isRecord(turn) ||
+				(turn.role !== "user" && turn.role !== "assistant") ||
+				typeof turn.content !== "string"
+			) {
+				throw new Error(`entry ${index} session ${sessionIndex} turn ${turnIndex} is invalid`);
+			}
+		}
+	}
+	const haystackIds = new Set(haystackSessionIds);
+	const missingAnswerSessionIds = answerSessionIds.filter((id) => !haystackIds.has(id));
+	if (missingAnswerSessionIds.length > 0) {
+		throw new Error(
+			`entry ${index} answer_session_ids missing from haystack: ${missingAnswerSessionIds.join(", ")}`,
+		);
+	}
+}
+
 /**
  * Load LongMemEval dataset from JSON file.
  */
 export async function loadLongMemEvalDatasetFromJson(jsonPath: string): Promise<LongMemEvalEntry[]> {
 	const content = await readFile(jsonPath, "utf-8");
-	const data = JSON.parse(content);
+	const data: unknown = JSON.parse(content);
 
 	if (!Array.isArray(data)) {
 		throw new Error(`Expected array of entries, got ${typeof data}`);
 	}
 
-	return data as LongMemEvalEntry[];
+	const ids = new Set<string>();
+	for (const [index, entry] of data.entries()) {
+		validateEntry(entry, index);
+		if (ids.has(entry.question_id)) throw new Error(`duplicate question_id: ${entry.question_id}`);
+		ids.add(entry.question_id);
+	}
+
+	return data;
 }

--- a/benchmark/longmemeval/src/diagnostics.test.ts
+++ b/benchmark/longmemeval/src/diagnostics.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRetrievalTrace, calculateDiagnosticSummary, deriveFailureStage } from "./diagnostics";
+import type { MemorySearchResponse } from "./opencontext-client";
+import { LONGMEMEVAL_TRACE_SCHEMA_VERSION } from "./types";
+import type { LongMemEvalEntry, LongMemEvalSessionTrace, Prediction } from "./types";
+
+function entry(): LongMemEvalEntry {
+	return {
+		question_id: "q1",
+		question_type: "multi-session",
+		question: "What pets did I adopt?",
+		question_date: "2024-02-01",
+		answer: "Luna and Milo",
+		answer_session_ids: ["s1", "s2"],
+		haystack_dates: ["2024-01-01", "2024-01-02"],
+		haystack_session_ids: ["s1", "s2"],
+		haystack_sessions: [[], []],
+	};
+}
+
+function session(messageId: string, sessionId: string): LongMemEvalSessionTrace {
+	return {
+		schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+		question_id: "q1",
+		message_id: messageId,
+		session_id: sessionId,
+		session_index: 0,
+		ingest_batch_index: 0,
+		session_date: "2024-01-01",
+		turn_count: 1,
+		content_sha256: "hash",
+		content_characters: 10,
+		ingest_status: "completed",
+		ingest_latency_ms: 5,
+		ingest_warnings: [],
+	};
+}
+
+describe("LongMemEval retrieval evidence", () => {
+	it("maps final daemon hits and pre-rerank channels back to gold sessions", () => {
+		const response: MemorySearchResponse = {
+			query: "What pets did I adopt?",
+			sources: ["memory"],
+			count: 2,
+			warnings: [],
+			results: [
+				{ id: "m2", content: "I adopted Milo.", similarity: 0.91, metadata: { sessionId: "s2" } },
+				{ id: "noise", content: "Unrelated", similarity: 0.7, metadata: { sessionId: "s9" } },
+			],
+			retrievalDiagnostics: {
+				mergeStrategy: "rrf",
+				candidateLimit: 20,
+				backend: "raw-message",
+				candidateCounts: { semantic: 2, lexical: 1, hybrid: 0, entity: 0, fused: 2, final: 2 },
+				channels: {
+					semantic: [
+						{ id: "m1", content: "I adopted Luna.", similarity: 0.8, metadata: { sessionId: "s1" } },
+					],
+					lexical: [],
+				},
+				fusedBeforeRerank: [
+					{ id: "m1", content: "I adopted Luna.", similarity: 0.8, metadata: { sessionId: "s1" } },
+					{ id: "m2", content: "I adopted Milo.", similarity: 0.7, metadata: { sessionId: "s2" } },
+				],
+				reranker: {
+					enabled: true,
+					provider: "local-transformers",
+					model: "reranker",
+					inputCount: 2,
+					outputCount: 2,
+					latencyMs: 12,
+					orderChanged: true,
+				},
+			},
+		};
+		const sessions = new Map([
+			["m1", session("m1", "s1")],
+			["m2", session("m2", "s2")],
+		]);
+
+		const trace = buildRetrievalTrace({
+			entry: entry(),
+			response,
+			sessionsByMessageId: sessions,
+			userId: "longmemeval_v1_q1",
+			topK: 8,
+			latencyMs: 20,
+		});
+
+		expect(trace.hits[0]).toMatchObject({
+			rank: 1,
+			session_ids: ["s2"],
+			matched_answer_session_ids: ["s2"],
+			relevant: true,
+		});
+		expect(trace.hits[0]?.content).toBe("I adopted Milo.");
+		expect(trace.candidate_channels.semantic[0]?.content).toBeUndefined();
+		expect(trace.semantic_answer_session_recall_at_candidate_k).toBe(0.5);
+		expect(trace.answer_session_recall_at_k).toBe(0.5);
+		expect(trace.hit_at_k).toBe(1);
+		expect(trace.mrr).toBe(1);
+		expect(trace.reranker).toMatchObject({ enabled: true, order_changed: true });
+		expect(deriveFailureStage({ entry: entry(), retrieval: trace, correct: false })).toBe(
+			"retrieval_partial",
+		);
+	});
+
+	it("keeps execution errors separate in the diagnostic summary", () => {
+		const prediction = {
+			status: "execution_error",
+			failure_stage: "answerer_error",
+			trace: { retrieval: null, answerer: null, judge: null },
+		} as Prediction;
+
+		expect(calculateDiagnosticSummary([prediction])).toMatchObject({
+			completed: 0,
+			execution_errors: 1,
+			execution_error_rate: 1,
+			failure_stages: { answerer_error: 1 },
+		});
+	});
+});

--- a/benchmark/longmemeval/src/diagnostics.ts
+++ b/benchmark/longmemeval/src/diagnostics.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+
+import type { MemorySearchResponse } from "./opencontext-client";
+import type {
+	LongMemEvalEntry,
+	LongMemEvalFailureStage,
+	LongMemEvalRetrievalTrace,
+	LongMemEvalSessionTrace,
+	Prediction,
+} from "./types";
+
+export function sha256Text(text: string): string {
+	return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function optionalString(value: unknown): string[] {
+	return typeof value === "string" ? [value] : [];
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+export function buildRetrievalTrace(input: {
+	entry: LongMemEvalEntry;
+	response: MemorySearchResponse;
+	sessionsByMessageId: ReadonlyMap<string, LongMemEvalSessionTrace>;
+	userId: string;
+	topK: number;
+	latencyMs: number;
+}): LongMemEvalRetrievalTrace {
+	const requiredIds = unique(input.entry.answer_session_ids);
+	const requiredSet = new Set(requiredIds);
+	const availableSet = new Set(input.entry.haystack_session_ids);
+	const availableRequiredIds = requiredIds.filter((id) => availableSet.has(id));
+	const missingSessionIds = requiredIds.filter((id) => !availableSet.has(id));
+	const retrievedRequiredIds = new Set<string>();
+
+	const mapHits = (sourceHits: MemorySearchResponse["results"], trackRetrieved: boolean) =>
+		sourceHits.map((hit, index) => {
+			const localSession = input.sessionsByMessageId.get(hit.id);
+			const sessionIds = unique([
+				...optionalString(hit.metadata.sessionId),
+				...optionalString(hit.metadata.session_id),
+				...stringArray(hit.metadata.sessionIds),
+				...stringArray(hit.metadata.session_ids),
+				...(localSession ? [localSession.session_id] : []),
+			]);
+			if (trackRetrieved) {
+				for (const sessionId of sessionIds) {
+					if (requiredSet.has(sessionId)) retrievedRequiredIds.add(sessionId);
+				}
+			}
+			const matchedAnswerSessionIds = sessionIds.filter((id) => requiredSet.has(id));
+			const relevant = requiredIds.length === 0 ? null : matchedAnswerSessionIds.length > 0;
+			return {
+				rank: index + 1,
+				id: hit.id,
+				similarity: hit.similarity,
+				signals: hit.signals ?? null,
+				metadata: hit.metadata,
+				content_sha256: sha256Text(hit.content),
+				content_characters: hit.content.length,
+				content_excerpt: hit.content.replace(/\s+/g, " ").trim().slice(0, 240),
+				...(trackRetrieved ? { content: hit.content } : {}),
+				session_ids: sessionIds,
+				matched_answer_session_ids: matchedAnswerSessionIds,
+				relevant,
+			};
+		});
+
+	const hits = mapHits(input.response.results, true);
+	const diagnostics = input.response.retrievalDiagnostics;
+	const candidateChannels = {
+		semantic: mapHits(diagnostics?.channels.semantic ?? [], false),
+		lexical: mapHits(diagnostics?.channels.lexical ?? [], false),
+		hybrid: mapHits(diagnostics?.channels.hybrid ?? [], false),
+		entity: mapHits(diagnostics?.channels.entity ?? [], false),
+	};
+	const fusedBeforeRerank = mapHits(diagnostics?.fusedBeforeRerank ?? [], false);
+	const channelRecall = (channelHits: typeof candidateChannels.semantic): number | null => {
+		if (requiredIds.length === 0) return null;
+		const matched = new Set(channelHits.flatMap((hit) => hit.matched_answer_session_ids));
+		return matched.size / requiredIds.length;
+	};
+
+	const relevantHits = hits.filter((hit) => hit.relevant === true);
+	const firstRelevantRank = relevantHits[0]?.rank ?? null;
+	const retrievalApplicable = requiredIds.length > 0;
+	const retrievedSessionIds = requiredIds.filter((id) => retrievedRequiredIds.has(id));
+	const missedSessionIds = requiredIds.filter((id) => !retrievedRequiredIds.has(id));
+
+	return {
+		status: "completed",
+		query: input.entry.question,
+		user_id: input.userId,
+		top_k: input.topK,
+		candidate_k: diagnostics?.candidateLimit ?? null,
+		strategy: "daemon-default",
+		merge_strategy: diagnostics?.mergeStrategy ?? null,
+		threshold: null,
+		backend: diagnostics?.backend ?? null,
+		semantic_degraded_reason: diagnostics?.semanticDegradedReason ?? null,
+		candidate_counts: diagnostics?.candidateCounts ?? null,
+		latency_ms: input.latencyMs,
+		response_query: input.response.query,
+		response_sources: input.response.sources,
+		response_count: input.response.count,
+		response_warnings: input.response.warnings,
+		response_reasoning: input.response.reasoning ?? null,
+		premerge_diagnostics_available: diagnostics !== undefined,
+		candidate_channels: candidateChannels,
+		fused_before_rerank: fusedBeforeRerank,
+		reranker: diagnostics?.reranker
+			? {
+					enabled: diagnostics.reranker.enabled,
+					provider: diagnostics.reranker.provider ?? null,
+					model: diagnostics.reranker.model ?? null,
+					input_count: diagnostics.reranker.inputCount,
+					output_count: diagnostics.reranker.outputCount,
+					latency_ms: diagnostics.reranker.latencyMs,
+					order_changed: diagnostics.reranker.orderChanged,
+				}
+			: null,
+		semantic_answer_session_recall_at_candidate_k: channelRecall(candidateChannels.semantic),
+		lexical_answer_session_recall_at_candidate_k: channelRecall(candidateChannels.lexical),
+		hybrid_answer_session_recall_at_candidate_k: channelRecall(candidateChannels.hybrid),
+		hits,
+		retrieval_applicable: retrievalApplicable,
+		required_answer_session_ids: requiredIds,
+		available_answer_session_ids: availableRequiredIds,
+		missing_answer_session_ids: missingSessionIds,
+		retrieved_answer_session_ids: retrievedSessionIds,
+		missed_answer_session_ids: missedSessionIds,
+		dataset_source_coverage: retrievalApplicable ? availableRequiredIds.length / requiredIds.length : null,
+		answer_session_recall_at_k: retrievalApplicable ? retrievedRequiredIds.size / requiredIds.length : null,
+		retrievable_answer_session_recall_at_k:
+			availableRequiredIds.length > 0 ? retrievedRequiredIds.size / availableRequiredIds.length : null,
+		all_answer_sessions_retrieved: retrievalApplicable
+			? retrievedRequiredIds.size === requiredIds.length
+			: null,
+		hit_at_k: retrievalApplicable ? (firstRelevantRank === null ? 0 : 1) : null,
+		first_relevant_rank: firstRelevantRank,
+		mrr: firstRelevantRank === null ? (retrievalApplicable ? 0 : null) : 1 / firstRelevantRank,
+		precision_at_k: retrievalApplicable ? relevantHits.length / input.topK : null,
+		relevant_hit_precision: retrievalApplicable
+			? hits.length === 0
+				? 0
+				: relevantHits.length / hits.length
+			: null,
+	};
+}
+
+export function buildRetrievalErrorTrace(input: {
+	entry: LongMemEvalEntry;
+	userId: string;
+	topK: number;
+	latencyMs: number;
+	error: string;
+}): LongMemEvalRetrievalTrace {
+	const requiredIds = unique(input.entry.answer_session_ids);
+	const availableSet = new Set(input.entry.haystack_session_ids);
+	const availableIds = requiredIds.filter((id) => availableSet.has(id));
+	const missingIds = requiredIds.filter((id) => !availableSet.has(id));
+	return {
+		status: "execution_error",
+		query: input.entry.question,
+		user_id: input.userId,
+		top_k: input.topK,
+		candidate_k: null,
+		strategy: "daemon-default",
+		merge_strategy: null,
+		threshold: null,
+		backend: null,
+		semantic_degraded_reason: null,
+		candidate_counts: null,
+		latency_ms: input.latencyMs,
+		response_query: input.entry.question,
+		response_sources: [],
+		response_count: 0,
+		response_warnings: [],
+		response_reasoning: null,
+		premerge_diagnostics_available: false,
+		candidate_channels: { semantic: [], lexical: [], hybrid: [], entity: [] },
+		fused_before_rerank: [],
+		reranker: null,
+		semantic_answer_session_recall_at_candidate_k: null,
+		lexical_answer_session_recall_at_candidate_k: null,
+		hybrid_answer_session_recall_at_candidate_k: null,
+		hits: [],
+		retrieval_applicable: requiredIds.length > 0,
+		required_answer_session_ids: requiredIds,
+		available_answer_session_ids: availableIds,
+		missing_answer_session_ids: missingIds,
+		retrieved_answer_session_ids: [],
+		missed_answer_session_ids: requiredIds,
+		dataset_source_coverage: requiredIds.length > 0 ? availableIds.length / requiredIds.length : null,
+		answer_session_recall_at_k: null,
+		retrievable_answer_session_recall_at_k: null,
+		all_answer_sessions_retrieved: null,
+		hit_at_k: null,
+		first_relevant_rank: null,
+		mrr: null,
+		precision_at_k: null,
+		relevant_hit_precision: null,
+		error: input.error,
+	};
+}
+
+export function deriveFailureStage(input: {
+	entry: LongMemEvalEntry;
+	retrieval: LongMemEvalRetrievalTrace | null;
+	correct: boolean;
+	executionStage?: "ingest" | "retrieval" | "answerer" | "judge" | "provider";
+}): LongMemEvalFailureStage {
+	if (input.executionStage === "ingest") return "ingest_or_index_error";
+	if (input.executionStage === "retrieval") return "retrieval_error";
+	if (input.executionStage === "answerer") return "answerer_error";
+	if (input.executionStage === "judge") return "judge_error";
+	if (input.executionStage === "provider") return "provider_error";
+	if (input.correct) return "none";
+	if (input.entry.answer_session_ids.length === 0) return "dataset_reference_missing";
+	if ((input.retrieval?.missing_answer_session_ids.length ?? 0) > 0) {
+		return input.retrieval?.available_answer_session_ids.length === 0
+			? "dataset_reference_missing"
+			: "dataset_reference_partial";
+	}
+	if (!input.retrieval || input.retrieval.answer_session_recall_at_k === 0) return "retrieval_miss";
+	if ((input.retrieval.answer_session_recall_at_k ?? 0) < 1) return "retrieval_partial";
+	return "context_present_answer_failed";
+}
+
+export function calculateDiagnosticSummary(predictions: Prediction[]): Record<string, unknown> {
+	const failureStages: Record<string, number> = {};
+	const recalls: number[] = [];
+	const retrievableRecalls: number[] = [];
+	const sourceCoverages: number[] = [];
+	const hitAtK: number[] = [];
+	const reciprocalRanks: number[] = [];
+	const precisionAtK: number[] = [];
+	const semanticCandidateRecalls: number[] = [];
+	const lexicalCandidateRecalls: number[] = [];
+	const hybridCandidateRecalls: number[] = [];
+	let completed = 0;
+	let executionErrors = 0;
+	let retrievalApplicable = 0;
+	let allSessionsRetrieved = 0;
+	let premergeDiagnostics = 0;
+
+	for (const prediction of predictions) {
+		failureStages[prediction.failure_stage] = (failureStages[prediction.failure_stage] ?? 0) + 1;
+		if (prediction.status === "completed") completed++;
+		else executionErrors++;
+		const retrieval = prediction.trace.retrieval;
+		if (retrieval?.premerge_diagnostics_available) premergeDiagnostics++;
+		if (!retrieval?.retrieval_applicable) continue;
+		retrievalApplicable++;
+		if (retrieval.all_answer_sessions_retrieved) allSessionsRetrieved++;
+		if (retrieval.answer_session_recall_at_k !== null) recalls.push(retrieval.answer_session_recall_at_k);
+		if (retrieval.retrievable_answer_session_recall_at_k !== null)
+			retrievableRecalls.push(retrieval.retrievable_answer_session_recall_at_k);
+		if (retrieval.dataset_source_coverage !== null) sourceCoverages.push(retrieval.dataset_source_coverage);
+		if (retrieval.hit_at_k !== null) hitAtK.push(retrieval.hit_at_k);
+		if (retrieval.mrr !== null) reciprocalRanks.push(retrieval.mrr);
+		if (retrieval.precision_at_k !== null) precisionAtK.push(retrieval.precision_at_k);
+		if (retrieval.semantic_answer_session_recall_at_candidate_k !== null)
+			semanticCandidateRecalls.push(retrieval.semantic_answer_session_recall_at_candidate_k);
+		if (retrieval.lexical_answer_session_recall_at_candidate_k !== null)
+			lexicalCandidateRecalls.push(retrieval.lexical_answer_session_recall_at_candidate_k);
+		if (retrieval.hybrid_answer_session_recall_at_candidate_k !== null)
+			hybridCandidateRecalls.push(retrieval.hybrid_answer_session_recall_at_candidate_k);
+	}
+
+	const mean = (values: number[]): number | null =>
+		values.length === 0 ? null : values.reduce((sum, value) => sum + value, 0) / values.length;
+	return {
+		completed,
+		execution_errors: executionErrors,
+		execution_error_rate: predictions.length === 0 ? 0 : executionErrors / predictions.length,
+		failure_stages: failureStages,
+		retrieval_applicable_questions: retrievalApplicable,
+		premerge_diagnostics_questions: premergeDiagnostics,
+		mean_semantic_answer_session_recall_at_candidate_k: mean(semanticCandidateRecalls),
+		mean_lexical_answer_session_recall_at_candidate_k: mean(lexicalCandidateRecalls),
+		mean_hybrid_answer_session_recall_at_candidate_k: mean(hybridCandidateRecalls),
+		mean_answer_session_recall_at_k: mean(recalls),
+		mean_retrievable_answer_session_recall_at_k: mean(retrievableRecalls),
+		mean_dataset_source_coverage: mean(sourceCoverages),
+		hit_at_k_rate: mean(hitAtK),
+		mean_precision_at_k: mean(precisionAtK),
+		mean_reciprocal_rank: mean(reciprocalRanks),
+		all_answer_sessions_retrieved_rate:
+			retrievalApplicable === 0 ? null : allSessionsRetrieved / retrievalApplicable,
+	};
+}

--- a/benchmark/longmemeval/src/evaluator.test.ts
+++ b/benchmark/longmemeval/src/evaluator.test.ts
@@ -20,18 +20,42 @@ vi.mock("./metrics", async (importOriginal) => {
 	};
 });
 
-import { LongMemEvalEvaluator } from "./evaluator";
-import { JUDGE_MODEL, evaluateLLMJudge, parseLLMJudgeResponse } from "./metrics";
+import { LongMemEvalEvaluator, buildSessionMessages } from "./evaluator";
+import { evaluateLLMJudge, getJudgeModelIdentity, parseLLMJudgeResponse } from "./metrics";
 import { generateAnswer, searchMemory } from "./opencontext-client";
 import type { LongMemEvalEntry } from "./types";
 
 const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
 const originalAnswerModel = process.env.ANSWER_MODEL;
+const originalJudgeModel = process.env.OPENROUTER_JUDGE_MODEL;
 const temporaryDirectories: string[] = [];
 const fixtureUsage = { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 };
 
 function judgeResult(score: number) {
-	return { score, token_usage: fixtureUsage };
+	return {
+		score,
+		token_usage: fixtureUsage,
+		status: "completed" as const,
+		attempt: 1,
+		latency_ms: 1,
+		prompt_version: "longmemeval-judge-v1",
+		prompt_sha256: "fixture-hash",
+		prompt_characters: 10,
+		system_prompt: "fixture system",
+		prompt: "fixture prompt",
+		raw_response: score === 1 ? '{"label":"CORRECT"}' : '{"label":"WRONG"}',
+		parse_status: "parsed" as const,
+	};
+}
+
+function searchResponse() {
+	return {
+		query: "fixture",
+		sources: ["memory"],
+		results: [],
+		count: 0,
+		warnings: [],
+	};
 }
 
 function restoreEnvironment(name: string, value: string | undefined): void {
@@ -69,13 +93,15 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	process.env.ANTHROPIC_AUTH_TOKEN = "fixture-token";
 	process.env.ANSWER_MODEL = "answerer-a";
-	vi.mocked(searchMemory).mockResolvedValue([]);
-	vi.mocked(generateAnswer).mockResolvedValue({ text: "fixture response", token_usage: fixtureUsage });
+	process.env.OPENROUTER_JUDGE_MODEL = "judge-a";
+	vi.mocked(searchMemory).mockResolvedValue(searchResponse());
+	vi.mocked(generateAnswer).mockResolvedValue({ text: "fixture response", token_usage: fixtureUsage, attempt: 1 });
 });
 
 afterEach(async () => {
 	restoreEnvironment("ANTHROPIC_AUTH_TOKEN", originalAuthToken);
 	restoreEnvironment("ANSWER_MODEL", originalAnswerModel);
+	restoreEnvironment("OPENROUTER_JUDGE_MODEL", originalJudgeModel);
 	await Promise.all(
 		temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
 	);
@@ -108,6 +134,28 @@ describe("LongMemEval checkpoint resume", () => {
 		expect(resumedAgain.correct).toBe(false);
 	});
 
+	it("restores raw-session evidence from a matched completed checkpoint without reingesting", async () => {
+		const checkpointDir = await createCheckpointDir();
+		const entry = createEntry("restored-entry");
+		entry.haystack_dates = ["2024-01-02"];
+		entry.haystack_session_ids = ["session-1"];
+		entry.haystack_sessions = [[{ role: "user", content: "Remember this." }]];
+		vi.mocked(evaluateLLMJudge).mockResolvedValueOnce(judgeResult(1));
+		await createEvaluator(checkpointDir).evaluateQuestion(entry);
+
+		const resumed = createEvaluator(checkpointDir);
+		const reused = await resumed.reuseCompletedCheckpoint(entry);
+
+		expect(reused).toMatchObject({ status: "completed", question_id: "restored-entry" });
+		expect(resumed.getSessionTraces()).toMatchObject([
+			{
+				message_id: "lme_restored-entry__session-1",
+				ingest_status: "completed",
+				ingest_latency_ms: null,
+			},
+		]);
+	});
+
 	it("retries execution errors and increments the attempt", async () => {
 		const checkpointDir = await createCheckpointDir();
 		const entry = createEntry("retry-entry");
@@ -117,7 +165,7 @@ describe("LongMemEval checkpoint resume", () => {
 		expect(failed).toMatchObject({
 			status: "execution_error",
 			attempt: 1,
-			error: "judge parse failure",
+			execution_error: { stage: "judge", message: "judge parse failure" },
 		});
 
 		vi.mocked(generateAnswer).mockClear();
@@ -156,7 +204,7 @@ describe("LongMemEval checkpoint resume", () => {
 		expect(generateAnswer).toHaveBeenCalledOnce();
 		expect(rerun).toMatchObject({
 			status: "completed",
-			attempt: 2,
+			attempt: 1,
 			answerer_model: "anthropic-compatible:answerer-b",
 		});
 
@@ -172,21 +220,21 @@ describe("LongMemEval checkpoint resume", () => {
 		expect(generateAnswer).toHaveBeenCalledOnce();
 		expect(judgeRerun).toMatchObject({
 			status: "completed",
-			attempt: 3,
-			judge_model: JUDGE_MODEL,
+			attempt: 1,
+			judge_model: getJudgeModelIdentity(),
 		});
 	});
 
 	it("records an empty answer as an execution error without calling the judge", async () => {
 		const checkpointDir = await createCheckpointDir();
-		vi.mocked(generateAnswer).mockResolvedValueOnce({ text: "", token_usage: fixtureUsage });
+		vi.mocked(generateAnswer).mockResolvedValueOnce({ text: "", token_usage: fixtureUsage, attempt: 1 });
 
 		const result = await createEvaluator(checkpointDir).evaluateQuestion(createEntry("empty-entry"));
 
 		expect(evaluateLLMJudge).not.toHaveBeenCalled();
 		expect(result).toMatchObject({
 			status: "execution_error",
-			error: "Answerer returned an empty response",
+			execution_error: { stage: "answerer", message: "Answerer returned an empty response" },
 		});
 	});
 });
@@ -196,5 +244,54 @@ describe("LongMemEval judge parsing", () => {
 		expect(parseLLMJudgeResponse('{"label":"CORRECT"}')).toBe(1);
 		expect(parseLLMJudgeResponse("WRONG")).toBe(0);
 		expect(() => parseLLMJudgeResponse("unknown")).toThrow("could not be parsed");
+	});
+});
+
+describe("LongMemEval raw-session mapping", () => {
+	it("preserves one complete dataset session as one raw message for daemon-owned chunking", () => {
+		const entry = createEntry("mapping-entry");
+		entry.haystack_dates = ["2024-01-02"];
+		entry.haystack_session_ids = ["session-1"];
+		entry.haystack_sessions = [
+			[
+				{ role: "user", content: "I adopted Luna." },
+				{ role: "assistant", content: "That is wonderful." },
+			],
+		];
+		entry.answer_session_ids = ["session-1"];
+
+		const built = buildSessionMessages(entry);
+
+		expect(built.messages).toHaveLength(1);
+		expect(built.messages[0]).toMatchObject({
+			messageId: "lme_mapping-entry__session-1",
+			metadata: { sessionId: "session-1", sessionDate: "2024-01-02", turnCount: 2 },
+		});
+		expect(built.messages[0]?.content).toContain("User: I adopted Luna.");
+		expect(built.messages[0]?.content).toContain("Assistant: That is wonderful.");
+		expect(built.sessions[0]).toMatchObject({
+			session_id: "session-1",
+			turn_count: 2,
+			ingest_status: "pending",
+		});
+	});
+
+	it("disambiguates duplicate dataset session ids without changing ordinary message ids", () => {
+		const entry = createEntry("duplicate-session-entry");
+		entry.haystack_dates = ["2024-01-02", "2024-01-03", "2024-01-04"];
+		entry.haystack_session_ids = ["same-session", "ordinary-session", "same-session"];
+		entry.haystack_sessions = [
+			[{ role: "user", content: "First duplicate." }],
+			[{ role: "user", content: "Ordinary." }],
+			[{ role: "user", content: "Second duplicate." }],
+		];
+
+		const built = buildSessionMessages(entry);
+
+		expect(built.messages.map((message) => message.messageId)).toEqual([
+			"lme_duplicate-session-entry__same-session__0",
+			"lme_duplicate-session-entry__ordinary-session",
+			"lme_duplicate-session-entry__same-session__2",
+		]);
 	});
 });

--- a/benchmark/longmemeval/src/evaluator.test.ts
+++ b/benchmark/longmemeval/src/evaluator.test.ts
@@ -95,7 +95,11 @@ beforeEach(() => {
 	process.env.ANSWER_MODEL = "answerer-a";
 	process.env.OPENROUTER_JUDGE_MODEL = "judge-a";
 	vi.mocked(searchMemory).mockResolvedValue(searchResponse());
-	vi.mocked(generateAnswer).mockResolvedValue({ text: "fixture response", token_usage: fixtureUsage, attempt: 1 });
+	vi.mocked(generateAnswer).mockResolvedValue({
+		text: "fixture response",
+		token_usage: fixtureUsage,
+		attempt: 1,
+	});
 });
 
 afterEach(async () => {

--- a/benchmark/longmemeval/src/evaluator.ts
+++ b/benchmark/longmemeval/src/evaluator.ts
@@ -12,14 +12,19 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { sumTokenUsage, unavailableTokenUsage } from "../../run-support";
-import { JUDGE_MODEL, calculateMetrics, evaluateLLMJudge } from "./metrics";
+import { buildRetrievalErrorTrace, buildRetrievalTrace, deriveFailureStage, sha256Text } from "./diagnostics";
+import { calculateMetrics, evaluateLLMJudge, getJudgeModelIdentity } from "./metrics";
 import {
+	AnswererGenerationError,
 	type BenchRawMessage,
-	type GeneratedAnswer,
+	INGEST_BATCH_SIZE,
+	type IngestBatchTrace,
+	IngestMessagesError,
 	type MemorySearchHit,
+	type MemorySearchResponse,
 	checkOpencontextHealth,
 	generateAnswer,
 	getAnswererModelIdentity,
@@ -27,22 +32,22 @@ import {
 	ingestMessages,
 	searchMemory,
 } from "./opencontext-client";
-import type { LongMemEvalEntry, Prediction } from "./types";
+import {
+	LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+	type LongMemEvalAnswerTrace,
+	type LongMemEvalEntry,
+	type LongMemEvalJudgeTrace,
+	type LongMemEvalRetrievalTrace,
+	type LongMemEvalSessionTrace,
+	type Prediction,
+} from "./types";
 
 /** How many retrieved sessions are shown to the answerer. */
-export const RETRIEVAL_LIMIT = 8;
-
-function isReusableCheckpoint(
-	prediction: Prediction | null,
-	answererModel: string,
-	judgeModel: string,
-): boolean {
-	return (
-		prediction?.status === "completed" &&
-		prediction.answerer_model === answererModel &&
-		prediction.judge_model === judgeModel
-	);
-}
+const configuredRetrievalLimit = Number.parseInt(process.env.LONGMEMEVAL_TOP_K ?? "8", 10);
+export const RETRIEVAL_LIMIT =
+	Number.isInteger(configuredRetrievalLimit) && configuredRetrievalLimit > 0
+		? Math.min(50, configuredRetrievalLimit)
+		: 8;
 
 /**
  * Parse timestamp string to Unix ms.
@@ -66,11 +71,19 @@ function parseTimestamp(ts: string): number | undefined {
  * memory store. One message per session; messageId is deterministic
  * (question_id + session_id) so re-ingestion stays idempotent.
  */
-function buildSessionMessages(entry: LongMemEvalEntry): BenchRawMessage[] {
+export function buildSessionMessages(entry: LongMemEvalEntry): {
+	messages: BenchRawMessage[];
+	sessions: LongMemEvalSessionTrace[];
+} {
 	const messages: BenchRawMessage[] = [];
+	const sessions: LongMemEvalSessionTrace[] = [];
 
 	const { haystack_sessions, haystack_session_ids, haystack_dates } = entry;
 	const now = Date.now();
+	const sessionIdOccurrences = new Map<string, number>();
+	for (const sessionId of haystack_session_ids) {
+		sessionIdOccurrences.set(sessionId, (sessionIdOccurrences.get(sessionId) ?? 0) + 1);
+	}
 
 	for (let i = 0; i < Math.min(haystack_sessions.length, haystack_session_ids.length); i++) {
 		const session = haystack_sessions[i];
@@ -90,30 +103,90 @@ function buildSessionMessages(entry: LongMemEvalEntry): BenchRawMessage[] {
 			parts.push(`${role}: ${turn.content}`);
 		}
 
+		// The dataset occasionally repeats a session id inside one haystack.
+		// Keep the normal stable id, but make duplicate occurrences independently
+		// addressable so their chunks cannot be merged by the daemon.
+		const messageId =
+			(sessionIdOccurrences.get(sessionId) ?? 0) > 1
+				? `lme_${entry.question_id}__${sessionId}__${i}`
+				: `lme_${entry.question_id}__${sessionId}`;
+		const content = parts.join("\n");
 		messages.push({
-			messageId: `lme_${entry.question_id}__${sessionId}`,
+			messageId,
 			userId: "benchmark_user",
 			platform: "benchmark",
 			botId: "longmemeval",
 			timestamp: parseTimestamp(date) ?? now,
-			content: parts.join("\n"),
+			content,
 			createdAt: now,
 			metadata: {
 				questionId: entry.question_id,
 				sessionId,
 				contentType: "session",
+				sessionDate: date || null,
+				turnCount: session.length,
 			},
+		});
+		sessions.push({
+			schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+			question_id: entry.question_id,
+			message_id: messageId,
+			session_id: sessionId,
+			session_index: i,
+			ingest_batch_index: Math.floor(i / INGEST_BATCH_SIZE),
+			session_date: date || null,
+			turn_count: session.length,
+			content_sha256: sha256Text(content),
+			content_characters: content.length,
+			ingest_status: "pending",
+			ingest_latency_ms: null,
+			ingest_warnings: [],
 		});
 	}
 
-	return messages;
+	return { messages, sessions };
+}
+
+export function fingerprintEntry(entry: LongMemEvalEntry): string {
+	return sha256Text(JSON.stringify(entry));
+}
+
+export function fingerprintQuestion(entry: LongMemEvalEntry): string {
+	return sha256Text(
+		JSON.stringify({
+			question_id: entry.question_id,
+			question_type: entry.question_type,
+			question: entry.question,
+			question_date: entry.question_date,
+			answer: entry.answer,
+			answer_session_ids: entry.answer_session_ids,
+		}),
+	);
+}
+
+function applyIngestBatchTraces(sessions: LongMemEvalSessionTrace[], batches: IngestBatchTrace[]): void {
+	const byMessageId = new Map(
+		batches.flatMap((batch) => batch.message_ids.map((messageId) => [messageId, batch] as const)),
+	);
+	for (const session of sessions) {
+		const batch = byMessageId.get(session.message_id);
+		if (!batch) {
+			session.ingest_status = "not_attempted";
+			continue;
+		}
+		session.ingest_status = batch.status;
+		session.ingest_latency_ms = batch.latency_ms;
+		session.ingest_warnings = batch.warnings;
+		if (batch.error) session.error = batch.error;
+	}
 }
 
 function buildAnswerPrompt(entry: LongMemEvalEntry, hits: MemorySearchHit[]): string {
 	// Build date context for temporal reasoning
+	const sortedDates = [...entry.haystack_dates].sort();
 	const dateRange =
-		entry.haystack_dates.length > 0
-			? `${Math.min(...entry.haystack_dates.map((d) => new Date(d).getTime())) > 0 ? entry.haystack_dates.sort()[0] : "unknown"} to ${entry.haystack_dates.sort()[entry.haystack_dates.length - 1]}`
+		sortedDates.length > 0
+			? `${Math.min(...sortedDates.map((d) => new Date(d).getTime())) > 0 ? sortedDates[0] : "unknown"} to ${sortedDates[sortedDates.length - 1]}`
 			: "unknown";
 
 	const excerpts = hits
@@ -188,20 +261,30 @@ ${
 
 export { checkOpencontextHealth, getOpencontextBaseUrl };
 
+/** Per-question user id so retrieval cannot cross-contaminate dataset entries. */
+function longMemEvalUserId(entry: LongMemEvalEntry): string {
+	return `longmemeval_v1_${entry.question_id}`;
+}
+
+export function getLongMemEvalCheckpointDir(): string {
+	const configured = process.env.LONGMEMEVAL_CHECKPOINT_DIR?.trim();
+	return configured ? resolve(configured) : join(import.meta.dirname, "..", "checkpoints", "longmemeval");
+}
+
 /**
  * Evaluator for LongMemEval benchmark using the OpenContext memory store.
  */
 export class LongMemEvalEvaluator {
 	private baseUrl: string;
-	private quickLimit?: number;
 	private checkpointDir: string;
 	private resume: boolean;
+	private sessionTraces = new Map<string, LongMemEvalSessionTrace>();
+	private entryFingerprints = new Map<string, string>();
 
-	constructor(baseUrl?: string, quickLimit?: number, resume = true) {
+	constructor(baseUrl?: string, _quickLimit?: number, resume = true) {
 		this.baseUrl = baseUrl ?? getOpencontextBaseUrl();
-		this.quickLimit = quickLimit;
 		this.resume = resume;
-		this.checkpointDir = join(import.meta.dirname, "..", "checkpoints", "longmemeval");
+		this.checkpointDir = getLongMemEvalCheckpointDir();
 	}
 
 	/**
@@ -233,61 +316,289 @@ export class LongMemEvalEvaluator {
 			await mkdir(this.checkpointDir, { recursive: true });
 			const path = this.getCheckpointPath(questionId);
 			await writeFile(path, JSON.stringify(prediction, null, 2), "utf-8");
-		} catch (_error) {}
+		} catch (error) {
+			process.stderr.write(`Failed to save checkpoint: ${error}\n`);
+		}
+	}
+
+	getSessionTraces(): LongMemEvalSessionTrace[] {
+		return [...this.sessionTraces.values()];
+	}
+
+	private checkpointMatchesEntry(checkpoint: Prediction | null, entry: LongMemEvalEntry): boolean {
+		const entrySha256 = this.entryFingerprints.get(entry.question_id) ?? fingerprintEntry(entry);
+		return (
+			checkpoint?.trace_schema_version === LONGMEMEVAL_TRACE_SCHEMA_VERSION &&
+			checkpoint.entry_sha256 === entrySha256 &&
+			checkpoint.question_sha256 === fingerprintQuestion(entry) &&
+			checkpoint.answerer_model === getAnswererModelIdentity() &&
+			checkpoint.judge_model === getJudgeModelIdentity()
+		);
+	}
+
+	/**
+	 * Reuse a completed checkpoint before attempting ingestion on a resumed run.
+	 *
+	 * A completed checkpoint can only have been written after the original
+	 * loadEntry call succeeded, so its raw-session mapping is restored locally
+	 * for the final evidence artifact without replaying an expensive idempotent
+	 * POST to the daemon. Failed and stale checkpoints deliberately return null:
+	 * those entries must still go through the daemon again.
+	 */
+	async reuseCompletedCheckpoint(entry: LongMemEvalEntry): Promise<Prediction | null> {
+		if (!this.resume) return null;
+		this.entryFingerprints.set(entry.question_id, fingerprintEntry(entry));
+		const checkpoint = await this.loadCheckpoint(entry.question_id);
+		if (checkpoint?.status !== "completed" || !this.checkpointMatchesEntry(checkpoint, entry)) return null;
+
+		const { sessions } = buildSessionMessages(entry);
+		for (const session of sessions) {
+			session.ingest_status = "completed";
+			session.ingest_warnings = [
+				"Restored from a context-matched completed checkpoint; original ingest latency was not persisted.",
+			];
+			this.sessionTraces.set(session.message_id, session);
+		}
+		return checkpoint;
+	}
+
+	createExecutionErrorPrediction(
+		entry: LongMemEvalEntry,
+		error: unknown,
+		stage: "ingest" | "retrieval" | "answerer" | "judge" | "provider",
+		attempt = 1,
+		trace: {
+			retrieval?: LongMemEvalRetrievalTrace | null;
+			answerer?: LongMemEvalAnswerTrace | null;
+			judge?: LongMemEvalJudgeTrace | null;
+		} = {},
+	): Prediction {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		const answer = String(entry.answer);
+		return {
+			trace_schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+			entry_sha256: this.entryFingerprints.get(entry.question_id) ?? fingerprintEntry(entry),
+			question_sha256: fingerprintQuestion(entry),
+			status: "execution_error",
+			attempt,
+			answerer_model: getAnswererModelIdentity(),
+			judge_model: getJudgeModelIdentity(),
+			execution_error: { stage, message: errorMessage },
+			token_usage: unavailableTokenUsage(),
+			question_id: entry.question_id,
+			question: entry.question,
+			question_date: entry.question_date,
+			answer,
+			response: `Error: ${errorMessage}`,
+			prediction: `Error: ${errorMessage}`,
+			ground_truth: answer,
+			question_type: entry.question_type,
+			llm_score: 0,
+			correct: false,
+			f1_score: 0,
+			bleu_score: 0,
+			bleu1: 0,
+			bleu2: 0,
+			bleu3: 0,
+			bleu4: 0,
+			evidence_session_ids: entry.answer_session_ids,
+			trace: {
+				retrieval: trace.retrieval ?? null,
+				answerer: trace.answerer ?? null,
+				judge: trace.judge ?? null,
+			},
+			failure_stage: deriveFailureStage({
+				entry,
+				retrieval: trace.retrieval ?? null,
+				correct: false,
+				executionStage: stage,
+			}),
+		};
 	}
 
 	/**
 	 * Ingest a LongMemEval entry into the OpenContext memory store.
 	 */
-	async loadEntry(entry: LongMemEvalEntry): Promise<void> {
-		const messages = buildSessionMessages(entry);
-		const _inserted = await ingestMessages(messages, this.baseUrl, `lme_${entry.question_id}`);
+	async loadEntry(entry: LongMemEvalEntry): Promise<number> {
+		const { messages, sessions } = buildSessionMessages(entry);
+		this.entryFingerprints.set(entry.question_id, fingerprintEntry(entry));
+		for (const session of sessions) this.sessionTraces.set(session.message_id, session);
+		const startedAt = performance.now();
+		try {
+			const result = await ingestMessages(messages, this.baseUrl, longMemEvalUserId(entry));
+			applyIngestBatchTraces(sessions, result.batches);
+			process.stdout.write(
+				`[LongMemEval] Ingested ${result.inserted} raw sessions for ${entry.question_id} → ${this.baseUrl}\n`,
+			);
+			return messages.length;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (error instanceof IngestMessagesError) applyIngestBatchTraces(sessions, error.result.batches);
+			else {
+				const latencyMs = Math.round(performance.now() - startedAt);
+				for (const session of sessions) {
+					session.ingest_status = "execution_error";
+					session.ingest_latency_ms = latencyMs;
+					session.error = message;
+				}
+			}
+			throw error;
+		}
 	}
 
 	/**
 	 * Evaluate a single question.
 	 */
 	async evaluateQuestion(entry: LongMemEvalEntry): Promise<Prediction> {
-		const checkpoint = await this.loadCheckpoint(entry.question_id);
 		const answererModel = getAnswererModelIdentity();
-		const judgeModel = JUDGE_MODEL;
-		if (checkpoint && isReusableCheckpoint(checkpoint, answererModel, judgeModel)) {
+		const judgeModel = getJudgeModelIdentity();
+		const entrySha256 = this.entryFingerprints.get(entry.question_id) ?? fingerprintEntry(entry);
+		const questionSha256 = fingerprintQuestion(entry);
+		const checkpoint = await this.loadCheckpoint(entry.question_id);
+		const checkpointMatchesContext = this.checkpointMatchesEntry(checkpoint, entry);
+		if (checkpoint?.status === "completed" && checkpointMatchesContext) {
 			return checkpoint;
 		}
 		if (checkpoint) {
 			const message =
 				checkpoint.status === "execution_error"
 					? `Retrying ${entry.question_id}: execution error`
-					: `Re-running ${entry.question_id}: legacy/model mismatch`;
+					: `Re-running ${entry.question_id}: trace, data, or model mismatch`;
 			process.stdout.write(`[LongMemEval] ${message}\n`);
 		}
-		const attempt = (checkpoint?.attempt ?? 0) + 1;
+		const attempt =
+			checkpoint !== null && checkpointMatchesContext && checkpoint.status === "execution_error"
+				? (checkpoint.attempt ?? 0) + 1
+				: 1;
 
-		// Convert answer to string (may be number in dataset)
 		const answerStr = String(entry.answer);
 		let answerUsage = unavailableTokenUsage();
 		let judgeUsage = unavailableTokenUsage();
+		let retrievalTrace: LongMemEvalRetrievalTrace | null = null;
+		let answerTrace: LongMemEvalAnswerTrace | null = null;
+		let judgeTrace: LongMemEvalJudgeTrace | null = null;
+		let executionStage: "retrieval" | "answerer" | "judge" = "retrieval";
 
 		try {
-			const answerResult = await this.queryMemory(entry);
-			const response = answerResult.text;
-			answerUsage = answerResult.token_usage;
+			const searchStartedAt = performance.now();
+			let searchResponse: MemorySearchResponse;
+			try {
+				searchResponse = await searchMemory(
+					entry.question,
+					RETRIEVAL_LIMIT,
+					this.baseUrl,
+					longMemEvalUserId(entry),
+					{ includeRetrievalDiagnostics: true },
+				);
+			} catch (error) {
+				retrievalTrace = buildRetrievalErrorTrace({
+					entry,
+					userId: longMemEvalUserId(entry),
+					topK: RETRIEVAL_LIMIT,
+					latencyMs: Math.round(performance.now() - searchStartedAt),
+					error: error instanceof Error ? error.message : String(error),
+				});
+				throw error;
+			}
+			const sessionsByMessageId = new Map(
+				this.getSessionTraces()
+					.filter((session) => session.question_id === entry.question_id)
+					.map((session) => [session.message_id, session] as const),
+			);
+			retrievalTrace = buildRetrievalTrace({
+				entry,
+				response: searchResponse,
+				sessionsByMessageId,
+				userId: longMemEvalUserId(entry),
+				topK: RETRIEVAL_LIMIT,
+				latencyMs: Math.round(performance.now() - searchStartedAt),
+			});
 
-			// Evaluate answer correctness using LLM judge
+			const hits = searchResponse.results;
+			const prompt = buildAnswerPrompt(entry, hits);
+			const contextCharacters = hits.reduce((sum, hit) => sum + hit.content.length, 0);
+			executionStage = "answerer";
+			const answerStartedAt = performance.now();
+			let response: string;
+			let answerAttempt = 1;
+			try {
+				const answerResult = await generateAnswer(prompt);
+				answerUsage = answerResult.token_usage;
+				response = answerResult.text;
+				answerAttempt = answerResult.attempt;
+				if (!response.trim()) throw new Error("Answerer returned an empty response");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				answerTrace = {
+					model: answererModel,
+					status: "execution_error",
+					attempt: error instanceof AnswererGenerationError ? error.attempts : 1,
+					latency_ms: Math.round(performance.now() - answerStartedAt),
+					prompt_version: "longmemeval-answer-v1",
+					prompt_sha256: sha256Text(prompt),
+					prompt_characters: prompt.length,
+					system_prompt: null,
+					prompt,
+					token_usage: answerUsage,
+					included_hit_ids: hits.map((hit) => hit.id),
+					included_context_characters: contextCharacters,
+					error: message,
+				};
+				throw error;
+			}
+			answerTrace = {
+				model: answererModel,
+				status: "completed",
+				attempt: answerAttempt,
+				latency_ms: Math.round(performance.now() - answerStartedAt),
+				prompt_version: "longmemeval-answer-v1",
+				prompt_sha256: sha256Text(prompt),
+				prompt_characters: prompt.length,
+				system_prompt: null,
+				prompt,
+				token_usage: answerUsage,
+				included_hit_ids: hits.map((hit) => hit.id),
+				included_context_characters: contextCharacters,
+			};
+
+			executionStage = "judge";
 			const judgeResult = await evaluateLLMJudge(entry.question, answerStr, response);
 			judgeUsage = judgeResult.token_usage;
-			const isCorrect = judgeResult.score === 1;
+			judgeTrace = {
+				model: judgeModel,
+				status: judgeResult.status,
+				attempt: judgeResult.attempt,
+				latency_ms: judgeResult.latency_ms,
+				prompt_version: judgeResult.prompt_version,
+				prompt_sha256: judgeResult.prompt_sha256,
+				prompt_characters: judgeResult.prompt_characters,
+				system_prompt: judgeResult.system_prompt,
+				prompt: judgeResult.prompt,
+				token_usage: judgeResult.token_usage,
+				raw_response: judgeResult.raw_response,
+				parse_status: judgeResult.parse_status,
+				...(judgeResult.error ? { error: judgeResult.error } : {}),
+			};
+			const executionError = judgeResult.status === "execution_error";
+			const isCorrect = !executionError && judgeResult.score === 1;
 
-			// Calculate additional metrics
 			const metrics = calculateMetrics(response, answerStr);
 
 			const pred: Prediction = {
-				status: "completed",
+				trace_schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+				entry_sha256: entrySha256,
+				question_sha256: questionSha256,
+				status: executionError ? "execution_error" : "completed",
 				attempt,
 				answerer_model: answererModel,
 				judge_model: judgeModel,
+				...(executionError
+					? { execution_error: { stage: "judge", message: judgeResult.error ?? "judge failure" } }
+					: {}),
 				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
+				question_id: entry.question_id,
 				question: entry.question,
+				question_date: entry.question_date,
 				answer: answerStr,
 				response,
 				prediction: response,
@@ -302,59 +613,27 @@ export class LongMemEvalEvaluator {
 				bleu3: metrics.bleu3,
 				bleu4: metrics.bleu4,
 				evidence_session_ids: entry.answer_session_ids,
+				trace: { retrieval: retrievalTrace, answerer: answerTrace, judge: judgeTrace },
+				failure_stage: deriveFailureStage({
+					entry,
+					retrieval: retrievalTrace,
+					correct: isCorrect,
+					...(executionError ? { executionStage: "judge" as const } : {}),
+				}),
 			};
 
-			// Save checkpoint
 			await this.saveCheckpoint(entry.question_id, pred);
 
 			return pred;
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-
-			const pred: Prediction = {
-				status: "execution_error",
-				attempt,
-				answerer_model: answererModel,
-				judge_model: judgeModel,
-				error: errorMessage,
-				token_usage: sumTokenUsage([answerUsage, judgeUsage]),
-				question: entry.question,
-				answer: answerStr,
-				response: `Error: ${errorMessage}`,
-				prediction: `Error: ${errorMessage}`,
-				ground_truth: answerStr,
-				question_type: entry.question_type,
-				llm_score: 0,
-				correct: false,
-				f1_score: 0.0,
-				bleu_score: 0.0,
-				bleu1: 0.0,
-				bleu2: 0.0,
-				bleu3: 0.0,
-				bleu4: 0.0,
-				evidence_session_ids: entry.answer_session_ids,
-			};
-
+			const pred = this.createExecutionErrorPrediction(entry, error, executionStage, attempt, {
+				retrieval: retrievalTrace,
+				answerer: answerTrace,
+				judge: judgeTrace,
+			});
+			pred.token_usage = sumTokenUsage([answerUsage, judgeUsage]);
 			await this.saveCheckpoint(entry.question_id, pred);
 			return pred;
 		}
-	}
-
-	/**
-	 * Retrieve relevant memories and answer the question with the answerer LLM.
-	 */
-	private async queryMemory(entry: LongMemEvalEntry): Promise<GeneratedAnswer> {
-		const hits = await searchMemory(
-			entry.question,
-			RETRIEVAL_LIMIT,
-			this.baseUrl,
-			`lme_${entry.question_id}`,
-		);
-		const prompt = buildAnswerPrompt(entry, hits);
-		const response = await generateAnswer(prompt);
-		if (!response.text.trim()) {
-			throw new Error("Answerer returned an empty response");
-		}
-		return response;
 	}
 }

--- a/benchmark/longmemeval/src/index.ts
+++ b/benchmark/longmemeval/src/index.ts
@@ -7,23 +7,18 @@
 import "dotenv/config";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import {
-	getManifestPath,
-	runPreflight,
-	sumTokenUsage,
-	unavailableTokenUsage,
-	writeRunManifest,
-} from "../../run-support";
+import { getManifestPath, runPreflight, sumTokenUsage, writeRunManifest } from "../../run-support";
 import { loadLongMemEvalDatasetFromJson } from "./dataset";
-import { LongMemEvalEvaluator, RETRIEVAL_LIMIT } from "./evaluator";
-import { JUDGE_MODEL, calculateCategoryMetrics } from "./metrics";
+import { calculateDiagnosticSummary } from "./diagnostics";
+import { LongMemEvalEvaluator, RETRIEVAL_LIMIT, getLongMemEvalCheckpointDir } from "./evaluator";
+import { calculateCategoryMetrics, getJudgeModelIdentity } from "./metrics";
 import {
 	checkOpencontextHealth,
 	getAnswererModelIdentity,
 	getOpencontextBaseUrl,
 } from "./opencontext-client";
 import { QUESTION_TYPE_NAMES } from "./scorer";
-import type { Prediction } from "./types";
+import { LONGMEMEVAL_TRACE_SCHEMA_VERSION, type Prediction } from "./types";
 
 interface CliArgs {
 	dataset: string;
@@ -32,6 +27,7 @@ interface CliArgs {
 	output?: string;
 	port?: number;
 	resume: boolean;
+	preflightOnly: boolean;
 }
 
 function parseCliArgs(): CliArgs {
@@ -39,6 +35,7 @@ function parseCliArgs(): CliArgs {
 	const values: Record<string, string | boolean | number | string[] | undefined> = {
 		quick: false,
 		resume: true,
+		preflightOnly: false,
 	};
 
 	for (let i = 0; i < args.length; i++) {
@@ -57,6 +54,8 @@ function parseCliArgs(): CliArgs {
 			values.resume = true;
 		} else if (arg === "--no-resume") {
 			values.resume = false;
+		} else if (arg === "--preflight-only") {
+			values.preflightOnly = true;
 		} else if (arg === "--help" || arg === "-h") {
 			printHelp();
 			process.exit(0);
@@ -80,6 +79,7 @@ function parseCliArgs(): CliArgs {
 		output: values.output as string | undefined,
 		port: values.port as number | undefined,
 		resume: values.resume !== false,
+		preflightOnly: values.preflightOnly === true,
 	};
 }
 
@@ -99,6 +99,8 @@ Filter:
 
 Mode:
       --resume / --no-resume  Reuse cached judge results (default: resume)
+      --preflight-only         Validate data, daemon, credentials, and paths;
+                               do not ingest or call answerer/judge models
 
 API:
   -p, --port <n>              OpenContext memory daemon port (default: 7421,
@@ -107,6 +109,23 @@ API:
 Output:
   -o, --output <path>         Write results JSON to this path
 `);
+}
+
+function diagnosticArtifactPath(outputPath: string, suffix: "trace" | "sessions"): string {
+	const resolved = resolve(outputPath);
+	const base = resolved.replace(/\.json$/i, "");
+	return `${base}.${suffix}.jsonl`;
+}
+
+async function writeJsonl(path: string, rows: unknown[]): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	const content = rows.map((row) => JSON.stringify(row)).join("\n");
+	await writeFile(path, content.length > 0 ? `${content}\n` : "", "utf-8");
+}
+
+function withoutDiagnosticTrace(prediction: Prediction): Omit<Prediction, "trace"> {
+	const { trace: _trace, ...result } = prediction;
+	return result;
 }
 
 async function printEvaluationSummary(resultsByType: Record<string, Prediction[]>): Promise<void> {
@@ -130,18 +149,25 @@ async function main() {
 	const baseUrl = args.port ? `http://127.0.0.1:${args.port}` : getOpencontextBaseUrl();
 	const benchmarkDir = join(import.meta.dirname, "..");
 	const manifestPath = getManifestPath(args.output, benchmarkDir, startedAt);
+	const tracePath = args.output ? diagnosticArtifactPath(args.output, "trace") : undefined;
+	const sessionsPath = args.output ? diagnosticArtifactPath(args.output, "sessions") : undefined;
 	let filteredEntries: Awaited<ReturnType<typeof loadLongMemEvalDatasetFromJson>> = [];
 	const parameterErrors: string[] = [];
 	if (args.port !== undefined && (!Number.isInteger(args.port) || args.port < 1 || args.port > 65_535)) {
 		parameterErrors.push("--port must be an integer between 1 and 65535");
+	}
+	if (!process.env.OPENROUTER_JUDGE_MODEL?.trim()) {
+		parameterErrors.push("judge model missing: set OPENROUTER_JUDGE_MODEL");
 	}
 
 	await runPreflight({
 		datasetPath: args.dataset,
 		writablePaths: [
 			manifestPath,
-			join(benchmarkDir, "checkpoints", "longmemeval", ".preflight"),
+			join(getLongMemEvalCheckpointDir(), ".preflight"),
 			...(args.output ? [args.output] : []),
+			...(tracePath ? [tracePath] : []),
+			...(sessionsPath ? [sessionsPath] : []),
 		],
 		parameterErrors,
 		validateDataset: async () => {
@@ -157,21 +183,29 @@ async function main() {
 		},
 		checkDaemon: () => checkOpencontextHealth(baseUrl),
 	});
+	if (args.preflightOnly) {
+		process.stdout.write(
+			`LongMemEval preflight passed: entries=${filteredEntries.length}, daemon=${baseUrl}, answerer=${getAnswererModelIdentity()}, judge=${getJudgeModelIdentity()}, top_k=${RETRIEVAL_LIMIT}\n`,
+		);
+		return;
+	}
 
 	// Run evaluation
 	const allPredictionsByType: Record<string, Prediction[]> = {};
 	let correct = 0;
 	let total = 0;
+	const evaluator = new LongMemEvalEvaluator(baseUrl, undefined, args.resume);
 
 	for (const entry of filteredEntries) {
-		const evaluator = new LongMemEvalEvaluator(baseUrl, undefined, args.resume);
-
 		try {
-			// Ingest entry into the memory store
-			await evaluator.loadEntry(entry);
-
-			// Evaluate question
-			const pred = await evaluator.evaluateQuestion(entry);
+			// A completed, context-matched checkpoint has already passed daemon
+			// ingestion. Rehydrate its raw-session mapping for evidence, but do not
+			// replay hundreds of idempotent ingestion calls before resuming work.
+			let pred = await evaluator.reuseCompletedCheckpoint(entry);
+			if (pred === null) {
+				await evaluator.loadEntry(entry);
+				pred = await evaluator.evaluateQuestion(entry);
+			}
 
 			// Organize predictions by question type
 			const qtype = pred.question_type;
@@ -185,32 +219,7 @@ async function main() {
 			}
 			total++;
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-
-			// Record failed prediction
-			const failedPred: Prediction = {
-				token_usage: unavailableTokenUsage(),
-				status: "execution_error",
-				attempt: 1,
-				answerer_model: getAnswererModelIdentity(),
-				judge_model: JUDGE_MODEL,
-				error: errorMessage,
-				question: entry.question,
-				answer: entry.answer,
-				response: `Error: ${errorMessage}`,
-				prediction: `Error: ${errorMessage}`,
-				ground_truth: entry.answer,
-				question_type: entry.question_type,
-				llm_score: 0,
-				correct: false,
-				f1_score: 0.0,
-				bleu_score: 0.0,
-				bleu1: 0.0,
-				bleu2: 0.0,
-				bleu3: 0.0,
-				bleu4: 0.0,
-				evidence_session_ids: entry.answer_session_ids,
-			};
+			const failedPred = evaluator.createExecutionErrorPrediction(entry, error, "ingest");
 
 			const qtype = entry.question_type;
 			if (!allPredictionsByType[qtype]) {
@@ -227,19 +236,27 @@ async function main() {
 	// Prepare output
 	const overallAccuracy = total > 0 ? correct / total : 0;
 	const predictions = Object.values(allPredictionsByType).flat();
+	const completedPredictions = predictions.filter((prediction) => prediction.status === "completed");
 	const runTokenUsage = sumTokenUsage(predictions.map((prediction) => prediction.token_usage));
+	const diagnosticSummary = calculateDiagnosticSummary(predictions);
 	const finishedAt = new Date().toISOString();
 	const runManifest = await writeRunManifest(manifestPath, {
 		benchmark: "longmemeval",
 		datasetPath: args.dataset,
 		answerer_model: getAnswererModelIdentity(),
-		judge_model: JUDGE_MODEL,
-		retrieval: { strategy: "memory-search", top_k: RETRIEVAL_LIMIT },
+		judge_model: getJudgeModelIdentity(),
+		retrieval: { strategy: "daemon-default", top_k: RETRIEVAL_LIMIT, diagnostics: true },
 		resume: args.resume,
 		started_at: startedAt,
 		finished_at: finishedAt,
 		token_usage: runTokenUsage,
-		parameters: { samples: args.samples ?? null, quick: args.quick ?? false },
+		parameters: {
+			samples: args.samples ?? null,
+			quick: args.quick ?? false,
+			trace_schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+			trace_artifact: tracePath ?? null,
+			sessions_artifact: sessionsPath ?? null,
+		},
 	});
 
 	const output = {
@@ -248,6 +265,20 @@ async function main() {
 		total_correct: correct,
 		overall_accuracy: overallAccuracy,
 		token_usage: runTokenUsage,
+		summary: {
+			all_records: calculateCategoryMetrics(predictions),
+			completed_only: calculateCategoryMetrics(completedPredictions),
+			execution_error_rate:
+				predictions.length === 0
+					? 0
+					: (predictions.length - completedPredictions.length) / predictions.length,
+		},
+		diagnostics: diagnosticSummary,
+		diagnostic_artifacts: {
+			trace_schema_version: LONGMEMEVAL_TRACE_SCHEMA_VERSION,
+			trace: tracePath ?? null,
+			sessions: sessionsPath ?? null,
+		},
 		run_manifest: runManifest,
 		results_by_type: Object.fromEntries(
 			Object.entries(allPredictionsByType).map(([qtype, preds]) => {
@@ -260,8 +291,12 @@ async function main() {
 						f1_mean: metrics.f1_mean,
 						bleu1_mean: metrics.bleu1_mean,
 						bleu4_mean: metrics.bleu4_mean,
+						completed_only: calculateCategoryMetrics(
+							preds.filter((prediction) => prediction.status === "completed"),
+						),
 						predictions: preds.map((p) => ({
-							question_id: p.question.slice(0, 50),
+							question_id: p.question_id,
+							status: p.status,
 							correct: p.correct,
 							llm_score: p.llm_score,
 							f1_score: p.f1_score,
@@ -276,7 +311,45 @@ async function main() {
 	// Save output if requested
 	if (args.output) {
 		await mkdir(dirname(resolve(args.output)), { recursive: true });
-		await writeFile(args.output, JSON.stringify(output, null, 2), "utf-8");
+		await writeFile(
+			args.output,
+			JSON.stringify(
+				{
+					...output,
+					predictions: output.predictions.map(withoutDiagnosticTrace),
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+		await writeJsonl(
+			tracePath as string,
+			predictions.map((prediction) => ({
+				schema_version: prediction.trace_schema_version,
+				question_id: prediction.question_id,
+				entry_sha256: prediction.entry_sha256,
+				question_sha256: prediction.question_sha256,
+				question: prediction.question,
+				question_date: prediction.question_date,
+				ground_truth: prediction.ground_truth,
+				evidence_session_ids: prediction.evidence_session_ids,
+				status: prediction.status,
+				attempt: prediction.attempt,
+				execution_error: prediction.execution_error ?? null,
+				failure_stage: prediction.failure_stage,
+				answerer_model: prediction.answerer_model,
+				judge_model: prediction.judge_model,
+				response: prediction.response,
+				llm_score: prediction.llm_score,
+				correct: prediction.correct,
+				token_usage: prediction.token_usage,
+				trace: prediction.trace,
+			})),
+		);
+		await writeJsonl(sessionsPath as string, evaluator.getSessionTraces());
+		process.stdout.write(`Question traces saved to: ${tracePath}\n`);
+		process.stdout.write(`Session ingest traces saved to: ${sessionsPath}\n`);
 	}
 	// biome-ignore lint/suspicious/noConsole: benchmark CLI reports the manifest artifact path
 	console.log(`Run manifest saved to: ${manifestPath}`);

--- a/benchmark/longmemeval/src/metrics.ts
+++ b/benchmark/longmemeval/src/metrics.ts
@@ -7,7 +7,7 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
-import { tokenUsage, type TokenUsage } from "../../run-support";
+import { tokenUsage, type TokenUsage, unavailableTokenUsage } from "../../run-support";
 
 const openrouter = createOpenAICompatible({
 	baseURL: "https://openrouter.ai/api/v1",
@@ -15,6 +15,18 @@ const openrouter = createOpenAICompatible({
 	name: "openrouter",
 });
 import { LLM_JUDGE_PROMPT } from "./prompts";
+import { sha256Text } from "./diagnostics";
+
+const configuredModelRequestTimeoutMs = Number.parseInt(
+	process.env.LONGMEMEVAL_MODEL_REQUEST_TIMEOUT_MS ?? "90000",
+	10,
+);
+const MODEL_REQUEST_TIMEOUT_MS =
+	Number.isInteger(configuredModelRequestTimeoutMs) && configuredModelRequestTimeoutMs >= 10_000
+		? configuredModelRequestTimeoutMs
+		: 90_000;
+const JUDGE_SYSTEM_PROMPT =
+	"You are an impartial judge evaluating answers to questions. Always respond with valid JSON.";
 
 /**
  * Calculate F1 score between prediction and ground truth.
@@ -143,11 +155,30 @@ interface LLMJudgeResult {
 	reasoning?: string;
 }
 
-export const JUDGE_MODEL = "qwen/qwen3.7-max";
+export function getJudgeModel(): string {
+	const model = process.env.OPENROUTER_JUDGE_MODEL?.trim();
+	if (!model) throw new Error("Judge model missing: set OPENROUTER_JUDGE_MODEL");
+	return model;
+}
+
+export function getJudgeModelIdentity(): string {
+	return `openrouter:${getJudgeModel()}`;
+}
 
 export interface LLMJudgeEvaluation {
 	score: number;
 	token_usage: TokenUsage;
+	status: "completed" | "execution_error";
+	attempt: number;
+	latency_ms: number;
+	prompt_version: string;
+	prompt_sha256: string;
+	prompt_characters: number;
+	system_prompt: string;
+	prompt: string;
+	raw_response: string | null;
+	parse_status: "parsed" | "failed";
+	error?: string;
 }
 
 export function parseLLMJudgeResponse(text: string): number {
@@ -185,35 +216,67 @@ export async function evaluateLLMJudge(
 	question: string,
 	goldAnswer: string,
 	generatedAnswer: string,
-	maxRetries = 3,
+	maxRetries = 5,
 ): Promise<LLMJudgeEvaluation> {
 	const prompt = LLM_JUDGE_PROMPT.replace("{question}", question)
 		.replace("{gold_answer}", goldAnswer)
 		.replace("{generated_answer}", generatedAnswer);
 
-	let _lastError: Error | undefined;
+	let lastError: Error | undefined;
+	let lastRawResponse: string | null = null;
+	let lastUsage = unavailableTokenUsage();
+	const startedAt = performance.now();
 
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			const { text, usage } = await generateText({
-				model: openrouter(JUDGE_MODEL),
-				system: "You are an impartial judge evaluating answers to questions. Always respond with valid JSON.",
+				model: openrouter(getJudgeModel()),
+				system: JUDGE_SYSTEM_PROMPT,
 				prompt,
+				// Keep retry ownership in this evaluator so its timeout is bounded.
+				maxRetries: 0,
+				abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
 			});
+			lastRawResponse = text;
+			lastUsage = tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens);
 
 			return {
 				score: parseLLMJudgeResponse(text),
-				token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+				token_usage: lastUsage,
+				status: "completed",
+				attempt,
+				latency_ms: Math.round(performance.now() - startedAt),
+				prompt_version: "longmemeval-judge-v1",
+				prompt_sha256: sha256Text(prompt),
+				prompt_characters: prompt.length,
+				system_prompt: JUDGE_SYSTEM_PROMPT,
+				prompt,
+				raw_response: text,
+				parse_status: "parsed",
 			};
 		} catch (error) {
-			_lastError = error instanceof Error ? error : new Error(String(error));
+			lastError = error instanceof Error ? error : new Error(String(error));
 			if (attempt < maxRetries) {
 				// Wait before retry (exponential backoff)
 				await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
 			}
 		}
 	}
-	throw _lastError ?? new Error("Judge failed without returning a result");
+	return {
+		score: 0,
+		token_usage: lastUsage,
+		status: "execution_error",
+		attempt: maxRetries,
+		latency_ms: Math.round(performance.now() - startedAt),
+		prompt_version: "longmemeval-judge-v1",
+		prompt_sha256: sha256Text(prompt),
+		prompt_characters: prompt.length,
+		system_prompt: JUDGE_SYSTEM_PROMPT,
+		prompt,
+		raw_response: lastRawResponse,
+		parse_status: "failed",
+		error: lastError?.message ?? "Judge failed without returning a result",
+	};
 }
 
 /**

--- a/benchmark/longmemeval/src/opencontext-client.test.ts
+++ b/benchmark/longmemeval/src/opencontext-client.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnswererGenerationError, retryAnswererOperation } from "./opencontext-client";
+
+describe("retryAnswererOperation", () => {
+	it("retries transient failures and reports the successful attempt", async () => {
+		const operation = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(new Error("timeout"))
+			.mockRejectedValueOnce(new Error("provider error"))
+			.mockResolvedValueOnce("answer");
+		const wait = vi.fn(async () => undefined);
+
+		await expect(retryAnswererOperation(operation, 3, wait)).resolves.toEqual({
+			result: "answer",
+			attempt: 3,
+		});
+		expect(operation).toHaveBeenCalledTimes(3);
+		expect(wait).toHaveBeenNthCalledWith(1, 1000);
+		expect(wait).toHaveBeenNthCalledWith(2, 2000);
+	});
+
+	it("fails with the attempt count after exhausting retries", async () => {
+		const operation = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("timeout"));
+		const wait = vi.fn(async () => undefined);
+
+		const error = await retryAnswererOperation(operation, 3, wait).catch((caught) => caught);
+		expect(error).toBeInstanceOf(AnswererGenerationError);
+		expect(error).toMatchObject({ attempts: 3 });
+		expect(error.message).toContain("Last error: timeout");
+		expect(operation).toHaveBeenCalledTimes(3);
+	});
+});

--- a/benchmark/longmemeval/src/opencontext-client.ts
+++ b/benchmark/longmemeval/src/opencontext-client.ts
@@ -69,9 +69,7 @@ export async function retryAnswererOperation<T>(
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 			if (attempt < maxAttempts) {
-				process.stderr.write(
-					`[Answerer] Attempt ${attempt}/${maxAttempts} failed: ${lastError.message}\n`,
-				);
+				process.stderr.write(`[Answerer] Attempt ${attempt}/${maxAttempts} failed: ${lastError.message}\n`);
 				await wait(1000 * attempt);
 			}
 		}
@@ -342,7 +340,10 @@ export async function searchMemory(
  * Fallback: OpenRouter chat completions:
  *   OPENROUTER_API_KEY / OPENROUTER_ANSWER_MODEL (default deepseek/deepseek-chat)
  */
-async function generateAnswerOnce(prompt: string, system?: string): Promise<Omit<GeneratedAnswer, "attempt">> {
+async function generateAnswerOnce(
+	prompt: string,
+	system?: string,
+): Promise<Omit<GeneratedAnswer, "attempt">> {
 	const token = process.env.ANTHROPIC_AUTH_TOKEN;
 	if (token) {
 		const base = (process.env.ANTHROPIC_BASE_URL ?? "https://api.minimaxi.com/anthropic").replace(/\/+$/, "");

--- a/benchmark/longmemeval/src/opencontext-client.ts
+++ b/benchmark/longmemeval/src/opencontext-client.ts
@@ -15,6 +15,14 @@
 import { tokenUsage, type TokenUsage } from "../../run-support";
 
 export const DEFAULT_OPENCONTEXT_PORT = 7421;
+const configuredModelRequestTimeoutMs = Number.parseInt(
+	process.env.LONGMEMEVAL_MODEL_REQUEST_TIMEOUT_MS ?? "90000",
+	10,
+);
+const MODEL_REQUEST_TIMEOUT_MS =
+	Number.isInteger(configuredModelRequestTimeoutMs) && configuredModelRequestTimeoutMs >= 10_000
+		? configuredModelRequestTimeoutMs
+		: 90_000;
 
 export function getOpencontextBaseUrl(): string {
 	if (process.env.OPENCONTEXT_URL) return process.env.OPENCONTEXT_URL;
@@ -34,6 +42,45 @@ export function getAnswererModelIdentity(): string {
 export interface GeneratedAnswer {
 	text: string;
 	token_usage: TokenUsage;
+	attempt: number;
+}
+
+export class AnswererGenerationError extends Error {
+	constructor(
+		message: string,
+		readonly attempts: number,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "AnswererGenerationError";
+	}
+}
+
+export async function retryAnswererOperation<T>(
+	operation: () => Promise<T>,
+	maxAttempts = 5,
+	wait: (delayMs: number) => Promise<void> = (delayMs) =>
+		new Promise((resolve) => setTimeout(resolve, delayMs)),
+): Promise<{ result: T; attempt: number }> {
+	let lastError: Error | undefined;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return { result: await operation(), attempt };
+		} catch (error) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+			if (attempt < maxAttempts) {
+				process.stderr.write(
+					`[Answerer] Attempt ${attempt}/${maxAttempts} failed: ${lastError.message}\n`,
+				);
+				await wait(1000 * attempt);
+			}
+		}
+	}
+	throw new AnswererGenerationError(
+		`Answerer failed after ${maxAttempts} attempts. Last error: ${lastError?.message ?? "unknown error"}`,
+		maxAttempts,
+		{ cause: lastError },
+	);
 }
 
 export async function checkOpencontextHealth(baseUrl = getOpencontextBaseUrl()): Promise<void> {
@@ -61,7 +108,34 @@ export interface BenchRawMessage {
 	metadata?: Record<string, unknown>;
 }
 
-const INGEST_BATCH_SIZE = 25;
+export const INGEST_BATCH_SIZE = 25;
+
+export interface IngestMessagesResult {
+	inserted: number;
+	warnings: unknown[];
+	batches: IngestBatchTrace[];
+}
+
+export interface IngestBatchTrace {
+	batch_index: number;
+	message_ids: string[];
+	requested: number;
+	inserted: number;
+	status: "completed" | "partial" | "execution_error";
+	latency_ms: number;
+	warnings: unknown[];
+	error?: string;
+}
+
+export class IngestMessagesError extends Error {
+	constructor(
+		message: string,
+		readonly result: IngestMessagesResult,
+	) {
+		super(message);
+		this.name = "IngestMessagesError";
+	}
+}
 
 /**
  * Ingest messages into the OpenContext memory store. `embedOnInsert: true`
@@ -72,30 +146,69 @@ export async function ingestMessages(
 	messages: BenchRawMessage[],
 	baseUrl = getOpencontextBaseUrl(),
 	userId = BENCH_USER_ID,
-): Promise<number> {
+): Promise<IngestMessagesResult> {
 	let inserted = 0;
+	const warnings: unknown[] = [];
+	const batches: IngestBatchTrace[] = [];
 	for (let i = 0; i < messages.length; i += INGEST_BATCH_SIZE) {
 		const batch = messages.slice(i, i + INGEST_BATCH_SIZE).map((m) => ({
 			...m,
 			userId,
 		}));
-		const res = await fetch(`${baseUrl}/v1/raw-messages`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				userId,
-				messages: batch,
-				embedOnInsert: true,
-			}),
-			signal: AbortSignal.timeout(600_000),
-		});
-		if (!res.ok) {
-			throw new Error(`ingest /v1/raw-messages failed: ${res.status} ${await res.text()}`);
+		const batchIndex = i / INGEST_BATCH_SIZE;
+		const startedAt = performance.now();
+		try {
+			const res = await fetch(`${baseUrl}/v1/raw-messages`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					userId,
+					messages: batch,
+					embedOnInsert: true,
+				}),
+				signal: AbortSignal.timeout(600_000),
+			});
+			if (!res.ok) {
+				throw new Error(`ingest /v1/raw-messages failed: ${res.status} ${await res.text()}`);
+			}
+			const data = (await res.json()) as { count?: number; warnings?: unknown[] };
+			const batchInserted = data.count ?? batch.length;
+			const batchWarnings = data.warnings ?? [];
+			inserted += batchInserted;
+			warnings.push(...batchWarnings);
+			const status = batchInserted === batch.length ? "completed" : "partial";
+			batches.push({
+				batch_index: batchIndex,
+				message_ids: batch.map((message) => message.messageId),
+				requested: batch.length,
+				inserted: batchInserted,
+				status,
+				latency_ms: Math.round(performance.now() - startedAt),
+				warnings: batchWarnings,
+			});
+			if (status === "partial") {
+				throw new IngestMessagesError(
+					`ingest inserted ${batchInserted} of ${batch.length} messages in batch ${batchIndex}`,
+					{ inserted, warnings, batches },
+				);
+			}
+		} catch (error) {
+			if (error instanceof IngestMessagesError) throw error;
+			const message = error instanceof Error ? error.message : String(error);
+			batches.push({
+				batch_index: batchIndex,
+				message_ids: batch.map((item) => item.messageId),
+				requested: batch.length,
+				inserted: 0,
+				status: "execution_error",
+				latency_ms: Math.round(performance.now() - startedAt),
+				warnings: [],
+				error: message,
+			});
+			throw new IngestMessagesError(message, { inserted, warnings, batches });
 		}
-		const data = (await res.json()) as { count?: number };
-		inserted += data.count ?? batch.length;
 	}
-	return inserted;
+	return { inserted, warnings, batches };
 }
 
 export interface MemorySearchHit {
@@ -103,6 +216,62 @@ export interface MemorySearchHit {
 	content: string;
 	similarity: number;
 	metadata: Record<string, unknown>;
+	signals?: Record<string, unknown>;
+}
+
+export interface MemorySearchEvidence {
+	id: string;
+	snippet: string;
+	score: number;
+	originalCharacters?: number;
+	startCharacter?: number;
+	endCharacter?: number;
+	truncated?: boolean;
+}
+
+export interface MemorySearchResponse {
+	query: string;
+	sources: string[];
+	results: MemorySearchHit[];
+	evidence?: MemorySearchEvidence[];
+	count: number;
+	warnings: unknown[];
+	reasoning?: unknown;
+	retrievalDiagnostics?: {
+		mergeStrategy: "rrf" | "similarity";
+		candidateLimit: number;
+		backend?: string;
+		semanticDegradedReason?: string;
+		candidateCounts?: {
+			semantic: number;
+			lexical: number;
+			hybrid: number;
+			entity: number;
+			fused: number;
+			final: number;
+		};
+		channels: {
+			semantic: MemorySearchHit[];
+			lexical: MemorySearchHit[];
+			hybrid?: MemorySearchHit[];
+			entity?: MemorySearchHit[];
+		};
+		fusedBeforeRerank: MemorySearchHit[];
+		reranker?: {
+			enabled: boolean;
+			provider?: string;
+			model?: string;
+			inputCount: number;
+			outputCount: number;
+			latencyMs: number;
+			orderChanged: boolean;
+		};
+		final?: MemorySearchHit[];
+	};
+}
+
+export interface MemorySearchOptions {
+	includeRetrievalDiagnostics?: boolean;
 }
 
 /** Retrieve relevant memories for a question. */
@@ -111,7 +280,8 @@ export async function searchMemory(
 	limit = 8,
 	baseUrl = getOpencontextBaseUrl(),
 	userId = BENCH_USER_ID,
-): Promise<MemorySearchHit[]> {
+	options: MemorySearchOptions = {},
+): Promise<MemorySearchResponse> {
 	const res = await fetch(`${baseUrl}/v1/search`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
@@ -119,6 +289,9 @@ export async function searchMemory(
 			userId,
 			query,
 			limit,
+			...(options.includeRetrievalDiagnostics === undefined
+				? {}
+				: { includeRetrievalDiagnostics: options.includeRetrievalDiagnostics }),
 			sources: ["memory"],
 		}),
 		signal: AbortSignal.timeout(120_000),
@@ -127,19 +300,38 @@ export async function searchMemory(
 		throw new Error(`search /v1/search failed: ${res.status} ${await res.text()}`);
 	}
 	const data = (await res.json()) as {
+		query?: string;
+		sources?: string[];
+		count?: number;
+		warnings?: unknown[];
+		reasoning?: unknown;
+		retrievalDiagnostics?: MemorySearchResponse["retrievalDiagnostics"];
+		evidence?: MemorySearchEvidence[];
 		results?: Array<{
 			id: string;
 			content: string;
 			similarity: number;
 			metadata?: Record<string, unknown>;
+			signals?: Record<string, unknown>;
 		}>;
 	};
-	return (data.results ?? []).map((r) => ({
+	const results = (data.results ?? []).map((r) => ({
 		id: r.id,
 		content: r.content,
 		similarity: r.similarity,
 		metadata: r.metadata ?? {},
+		...(r.signals ? { signals: r.signals } : {}),
 	}));
+	return {
+		query: data.query ?? query,
+		sources: data.sources ?? [],
+		results,
+		evidence: data.evidence ?? [],
+		count: data.count ?? results.length,
+		warnings: data.warnings ?? [],
+		...(data.reasoning === undefined ? {} : { reasoning: data.reasoning }),
+		...(data.retrievalDiagnostics === undefined ? {} : { retrievalDiagnostics: data.retrievalDiagnostics }),
+	};
 }
 
 /**
@@ -150,7 +342,7 @@ export async function searchMemory(
  * Fallback: OpenRouter chat completions:
  *   OPENROUTER_API_KEY / OPENROUTER_ANSWER_MODEL (default deepseek/deepseek-chat)
  */
-export async function generateAnswer(prompt: string, system?: string): Promise<GeneratedAnswer> {
+async function generateAnswerOnce(prompt: string, system?: string): Promise<Omit<GeneratedAnswer, "attempt">> {
 	const token = process.env.ANTHROPIC_AUTH_TOKEN;
 	if (token) {
 		const base = (process.env.ANTHROPIC_BASE_URL ?? "https://api.minimaxi.com/anthropic").replace(/\/+$/, "");
@@ -202,9 +394,22 @@ export async function generateAnswer(prompt: string, system?: string): Promise<G
 		model: openrouter(process.env.OPENROUTER_ANSWER_MODEL ?? "deepseek/deepseek-chat"),
 		...(system ? { system } : {}),
 		prompt,
+		// The outer retry loop owns retry and timeout policy. Leaving SDK retries
+		// enabled can keep a single benchmark question stuck beyond its deadline.
+		maxRetries: 0,
+		abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
 	});
 	return {
 		text,
 		token_usage: tokenUsage(usage.inputTokens, usage.outputTokens, usage.totalTokens),
 	};
+}
+
+export async function generateAnswer(prompt: string, system?: string): Promise<GeneratedAnswer> {
+	const { result, attempt } = await retryAnswererOperation(async () => {
+		const generated = await generateAnswerOnce(prompt, system);
+		if (!generated.text.trim()) throw new Error("Answerer returned an empty response");
+		return generated;
+	});
+	return { ...result, attempt };
 }

--- a/benchmark/longmemeval/src/types.ts
+++ b/benchmark/longmemeval/src/types.ts
@@ -27,6 +27,150 @@ export interface LongMemEvalEntry {
 	haystack_sessions: ConversationTurn[][];
 }
 
+export const LONGMEMEVAL_TRACE_SCHEMA_VERSION = "1.0";
+
+export type LongMemEvalExecutionStatus = "completed" | "execution_error";
+
+export type LongMemEvalFailureStage =
+	| "none"
+	| "dataset_reference_missing"
+	| "dataset_reference_partial"
+	| "ingest_or_index_error"
+	| "retrieval_error"
+	| "retrieval_miss"
+	| "retrieval_partial"
+	| "answerer_error"
+	| "context_present_answer_failed"
+	| "judge_error"
+	| "provider_error";
+
+export interface LongMemEvalSessionTrace {
+	schema_version: string;
+	question_id: string;
+	message_id: string;
+	session_id: string;
+	session_index: number;
+	ingest_batch_index: number;
+	session_date: string | null;
+	turn_count: number;
+	content_sha256: string;
+	content_characters: number;
+	ingest_status: "pending" | "not_attempted" | "completed" | "partial" | "execution_error";
+	ingest_latency_ms: number | null;
+	ingest_warnings: unknown[];
+	error?: string;
+}
+
+export interface LongMemEvalRetrievalHitTrace {
+	rank: number;
+	id: string;
+	similarity: number;
+	signals: Record<string, unknown> | null;
+	metadata: Record<string, unknown>;
+	content_sha256: string;
+	content_characters: number;
+	content_excerpt: string;
+	/** Full text is retained for final Top-K hits; candidate channels retain hash/excerpt only. */
+	content?: string;
+	session_ids: string[];
+	matched_answer_session_ids: string[];
+	relevant: boolean | null;
+}
+
+export interface LongMemEvalRetrievalTrace {
+	status: "completed" | "execution_error";
+	query: string;
+	user_id: string;
+	top_k: number;
+	candidate_k: number | null;
+	strategy: "daemon-default";
+	merge_strategy: "rrf" | "similarity" | null;
+	threshold: null;
+	backend: string | null;
+	semantic_degraded_reason: string | null;
+	candidate_counts: {
+		semantic: number;
+		lexical: number;
+		hybrid: number;
+		entity: number;
+		fused: number;
+		final: number;
+	} | null;
+	latency_ms: number;
+	response_query: string;
+	response_sources: string[];
+	response_count: number;
+	response_warnings: unknown[];
+	response_reasoning: unknown | null;
+	premerge_diagnostics_available: boolean;
+	candidate_channels: {
+		semantic: LongMemEvalRetrievalHitTrace[];
+		lexical: LongMemEvalRetrievalHitTrace[];
+		hybrid: LongMemEvalRetrievalHitTrace[];
+		entity: LongMemEvalRetrievalHitTrace[];
+	};
+	fused_before_rerank: LongMemEvalRetrievalHitTrace[];
+	reranker: {
+		enabled: boolean;
+		provider: string | null;
+		model: string | null;
+		input_count: number;
+		output_count: number;
+		latency_ms: number;
+		order_changed: boolean;
+	} | null;
+	semantic_answer_session_recall_at_candidate_k: number | null;
+	lexical_answer_session_recall_at_candidate_k: number | null;
+	hybrid_answer_session_recall_at_candidate_k: number | null;
+	hits: LongMemEvalRetrievalHitTrace[];
+	retrieval_applicable: boolean;
+	required_answer_session_ids: string[];
+	available_answer_session_ids: string[];
+	missing_answer_session_ids: string[];
+	retrieved_answer_session_ids: string[];
+	missed_answer_session_ids: string[];
+	dataset_source_coverage: number | null;
+	answer_session_recall_at_k: number | null;
+	retrievable_answer_session_recall_at_k: number | null;
+	all_answer_sessions_retrieved: boolean | null;
+	hit_at_k: number | null;
+	first_relevant_rank: number | null;
+	mrr: number | null;
+	precision_at_k: number | null;
+	relevant_hit_precision: number | null;
+	error?: string;
+}
+
+export interface LongMemEvalModelCallTrace {
+	model: string;
+	status: "completed" | "skipped" | "execution_error";
+	attempt: number;
+	latency_ms: number;
+	prompt_version: string;
+	prompt_sha256: string | null;
+	prompt_characters: number;
+	system_prompt: string | null;
+	prompt: string | null;
+	token_usage: TokenUsage;
+	error?: string;
+}
+
+export interface LongMemEvalAnswerTrace extends LongMemEvalModelCallTrace {
+	included_hit_ids: string[];
+	included_context_characters: number;
+}
+
+export interface LongMemEvalJudgeTrace extends LongMemEvalModelCallTrace {
+	raw_response: string | null;
+	parse_status: "parsed" | "skipped" | "failed";
+}
+
+export interface LongMemEvalQuestionTrace {
+	retrieval: LongMemEvalRetrievalTrace | null;
+	answerer: LongMemEvalAnswerTrace | null;
+	judge: LongMemEvalJudgeTrace | null;
+}
+
 /**
  * Evaluation result for a single sample.
  */
@@ -45,14 +189,19 @@ export interface EvaluationResult {
  * Prediction result for a single question.
  */
 export interface Prediction {
-	status: "completed" | "execution_error";
+	trace_schema_version: string;
+	entry_sha256: string;
+	question_sha256: string;
+	status: LongMemEvalExecutionStatus;
 	attempt: number;
 	answerer_model: string;
 	judge_model: string;
-	error?: string;
+	execution_error?: { stage: string; message: string };
 	token_usage: TokenUsage;
+	question_id: string;
 	question: string;
-	answer: string;
+	question_date: string;
+	answer: string | number;
 	response: string;
 	prediction: string;
 	ground_truth: string;
@@ -66,4 +215,6 @@ export interface Prediction {
 	bleu3: number;
 	bleu4: number;
 	evidence_session_ids: string[];
+	trace: LongMemEvalQuestionTrace;
+	failure_stage: LongMemEvalFailureStage;
 }

--- a/benchmark/longmemeval/start-daemon.ps1
+++ b/benchmark/longmemeval/start-daemon.ps1
@@ -1,0 +1,120 @@
+param(
+  [ValidateRange(1, 65535)]
+  [int]$Port = 7421,
+
+  [string]$DatabasePath
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$runtimeRoot = Join-Path $PSScriptRoot "runtime"
+$launchTag = Get-Date -Format "yyyyMMdd-HHmmss"
+if ($DatabasePath) {
+  if (-not (Test-Path -LiteralPath $DatabasePath -PathType Leaf)) {
+    throw "Existing database not found: $DatabasePath"
+  }
+  $dbPath = (Resolve-Path -LiteralPath $DatabasePath).Path
+  $runtimeDir = Split-Path -Parent $dbPath
+  $stdoutPath = Join-Path $runtimeDir "daemon-resume-$launchTag.stdout.log"
+  $stderrPath = Join-Path $runtimeDir "daemon-resume-$launchTag.stderr.log"
+} else {
+  $runtimeDir = Join-Path $runtimeRoot $launchTag
+  $dbPath = Join-Path $runtimeDir "store.db"
+  $stdoutPath = Join-Path $runtimeDir "daemon.stdout.log"
+  $stderrPath = Join-Path $runtimeDir "daemon.stderr.log"
+}
+$cliPath = Join-Path $repoRoot "packages\opencontext\dist\cli\opencontext.js"
+
+if (-not (Test-Path -LiteralPath $cliPath)) {
+  throw "OpenContext CLI is not built: $cliPath"
+}
+if (Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue) {
+  throw "Port $Port already has a listener; refusing to replace it."
+}
+
+New-Item -ItemType Directory -Force -Path $runtimeDir | Out-Null
+
+$previousDbPath = $env:MEMORY_STORE_DB_PATH
+$previousRawStoreBackend = $env:OPENCONTEXT_MEMORY_STORE_BACKEND
+$previousRerankerDtype = $env:LOCAL_RERANKER_DTYPE
+$previousRerankerLocalOnly = $env:LOCAL_RERANKER_LOCAL_ONLY
+try {
+  $env:MEMORY_STORE_DB_PATH = $dbPath
+  $env:OPENCONTEXT_MEMORY_STORE_BACKEND = "sqlite"
+  $env:LOCAL_RERANKER_DTYPE = "q8"
+  $env:LOCAL_RERANKER_LOCAL_ONLY = "true"
+
+  $arguments = @(
+    $cliPath,
+    "http",
+    "--host", "127.0.0.1",
+    "--port", [string]$Port,
+    "--embedding-provider", "local",
+    "--embedding-model", "Xenova/all-MiniLM-L6-v2",
+    "--embedding-cache-dir", (Join-Path $env:USERPROFILE ".cache\opencontext\local-embeddings"),
+    "--memory-backend", "sqlite-vec",
+    "--reranker-provider", "local",
+    "--reranker-model", "Xenova/ms-marco-MiniLM-L-6-v2",
+    "--reranker-cache-dir", (Join-Path $env:USERPROFILE ".cache\opencontext\local-reranker"),
+    "--reranker-batch-size", "8",
+    "--reranker-max-tokens", "512",
+    "--insights-backend", "none",
+    "--knowledge-backend", "none"
+  )
+  $process = Start-Process `
+    -FilePath "node" `
+    -ArgumentList $arguments `
+    -WorkingDirectory $repoRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -WindowStyle Hidden `
+    -PassThru
+} finally {
+  if ($null -eq $previousDbPath) { Remove-Item Env:MEMORY_STORE_DB_PATH -ErrorAction SilentlyContinue }
+  else { $env:MEMORY_STORE_DB_PATH = $previousDbPath }
+  if ($null -eq $previousRawStoreBackend) { Remove-Item Env:OPENCONTEXT_MEMORY_STORE_BACKEND -ErrorAction SilentlyContinue }
+  else { $env:OPENCONTEXT_MEMORY_STORE_BACKEND = $previousRawStoreBackend }
+  if ($null -eq $previousRerankerDtype) { Remove-Item Env:LOCAL_RERANKER_DTYPE -ErrorAction SilentlyContinue }
+  else { $env:LOCAL_RERANKER_DTYPE = $previousRerankerDtype }
+  if ($null -eq $previousRerankerLocalOnly) { Remove-Item Env:LOCAL_RERANKER_LOCAL_ONLY -ErrorAction SilentlyContinue }
+  else { $env:LOCAL_RERANKER_LOCAL_ONLY = $previousRerankerLocalOnly }
+}
+
+$healthy = $false
+for ($attempt = 0; $attempt -lt 60; $attempt++) {
+  try {
+    Invoke-RestMethod -Uri "http://127.0.0.1:$Port/health" -TimeoutSec 2 | Out-Null
+    $healthy = $true
+    break
+  } catch {
+    if ($process.HasExited) { break }
+    Start-Sleep -Seconds 1
+  }
+}
+
+if (-not $healthy) {
+  if (-not $process.HasExited) { Stop-Process -Id $process.Id }
+  $details = if (Test-Path -LiteralPath $stderrPath) {
+    (Get-Content -LiteralPath $stderrPath -Tail 80) -join [Environment]::NewLine
+  } else {
+    "No stderr log was created."
+  }
+  throw "Daemon failed health check. $details"
+}
+
+$metadata = [ordered]@{
+  pid = $process.Id
+  port = $Port
+  database = $dbPath
+  stdout = $stdoutPath
+  stderr = $stderrPath
+  started_at = (Get-Date).ToString("o")
+  embedding_provider = "local"
+  embedding_model = "Xenova/all-MiniLM-L6-v2"
+  memory_backend = "sqlite-vec"
+  reranker_provider = "local"
+  reranker_model = "Xenova/ms-marco-MiniLM-L-6-v2"
+  resumed_database = [bool]$DatabasePath
+}
+$metadata | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $runtimeDir "daemon.json") -Encoding utf8
+$metadata | ConvertTo-Json

--- a/benchmark/run-support.ts
+++ b/benchmark/run-support.ts
@@ -4,7 +4,7 @@ import { constants, createReadStream } from "node:fs";
 import { access, mkdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
-const MAX_HASH_BYTES = 256 * 1024 * 1024;
+const MAX_HASH_BYTES = 512 * 1024 * 1024;
 
 export interface TokenUsage {
 	prompt_tokens: number | null;
@@ -23,6 +23,8 @@ export interface RunManifest {
 	schema_version: 1;
 	benchmark: string;
 	git_commit: string | null;
+	git_dirty: boolean | null;
+	git_status: string[];
 	dataset: DatasetIdentity;
 	answerer_model: string;
 	judge_model: string;
@@ -97,11 +99,17 @@ export async function getDatasetIdentity(path: string): Promise<DatasetIdentity>
 	};
 }
 
-function getGitCommit(): string | null {
+function getGitState(): { commit: string | null; dirty: boolean | null; status: string[] } {
 	try {
-		return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8" }).trim() || null;
+		const commit = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8" }).trim() || null;
+		const status = execFileSync("git", ["status", "--porcelain=v1", "--untracked-files=all"], {
+			encoding: "utf-8",
+		})
+			.split(/\r?\n/)
+			.filter((line) => line.length > 0);
+		return { commit, dirty: status.length > 0, status };
 	} catch {
-		return null;
+		return { commit: null, dirty: null, status: [] };
 	}
 }
 
@@ -182,16 +190,22 @@ export function getManifestPath(output: string | undefined, benchmarkDir: string
 
 export async function writeRunManifest(
 	path: string,
-	input: Omit<RunManifest, "schema_version" | "git_commit" | "dataset" | "wall_clock_ms"> & {
+	input: Omit<
+		RunManifest,
+		"schema_version" | "git_commit" | "git_dirty" | "git_status" | "dataset" | "wall_clock_ms"
+	> & {
 		datasetPath: string;
 	},
 ): Promise<RunManifest> {
 	const started = Date.parse(input.started_at);
 	const finished = Date.parse(input.finished_at);
+	const git = getGitState();
 	const manifest: RunManifest = {
 		schema_version: 1,
 		benchmark: input.benchmark,
-		git_commit: getGitCommit(),
+		git_commit: git.commit,
+		git_dirty: git.dirty,
+		git_status: git.status,
 		dataset: await getDatasetIdentity(input.datasetPath),
 		answerer_model: input.answerer_model,
 		judge_model: input.judge_model,


### PR DESCRIPTION
## Summary

Complete the OpenContext LongMemEval evaluation evidence chain and add the v1 result report.

- Add dataset-to-raw-message mapping, deterministic session ingestion, checkpoint resume, and daemon startup support.
- Record per-question ingestion, retrieval, answer generation, judge, and diagnostic evidence.
- Add retrieval/failure diagnostics and focused coverage for retry, resume, duplicate-session, and evidence-chain behavior.
- Document the completed 500-question LongMemEval v1 result.

## Result

- Completed: 500 / 500
- Execution errors: 0
- Judge Accuracy: 48.20% (241 / 500)
- Answer-session Recall@8: 0.9123
- Retrieval Hit@8: 0.9640
- Sessions ingested: 23,867
- Answerer: `openrouter:deepseek/deepseek-v4-flash-0731`
- Judge: `openrouter:qwen/qwen3.8-flash`

## Validation

- `pnpm --filter @melandlabs/benchmark-longmemeval lint`
- `pnpm --filter @melandlabs/benchmark-longmemeval typecheck`
- `pnpm --filter @melandlabs/benchmark-longmemeval test`

## Notes

- The report links the result JSON, manifest, trace, and session-ingestion artifact.
- The completed run was recovered with `--resume=true` from a dirty worktree. It is a complete execution artifact, but not a frozen-code, clean-DB, `--no-resume` comparison baseline or an official AML leaderboard score.
- This PR depends on `fix/core-memory-child-retrieval-reranking`; use that branch as the PR base until it is merged.