### PR TITLE
docs(readme): rewrite first-screen copy with hook + positioning

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -2,9 +2,17 @@
 
 # OpenContext
 
-**Agentic 应用的上下文运行时底座，让应用真正能自主行动**
+**你的 Agent 做完决策就忘了为什么。OpenContext 把『为什么』找回来。**
 
-一个时序上下文图谱、一套记忆 API、一组检索能力，以及一个跨平台集成网格 —— 整体可作为一个依赖嵌入到任何宿主进程或 agent 里。
+_面向 AI Agent 的上下文层 —— 时序上下文图谱 + 记忆 API + 自进化回路，一个依赖搞定。_
+
+</div>
+
+**上下文才是缺失的那一层。** 检索告诉你『发生了什么』，OpenContext 告诉你『发生的事是如何变成现在这样的』。
+
+**其他记忆库只做检索，OpenContext 把『为什么』留住** —— 时序时间线、信念修正、出处全程可溯。
+
+<div align="center">
 
 <p align="center">
 <a href="./README.md">English</a> · <a href="./README-zh.md">简体中文</a>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 # OpenContext
 
-**The agentic context runtime, powering applications that act on your behalf.**
+**Your agent forgets why it made decisions. OpenContext fixes that.**
 
-A temporal context graph, a memory API, retrieval primitives,
-and a multi-platform integration mesh — designed to be embedded into any
-host process or agents.
+_The context layer for AI agents — a temporal context graph, memory API, and self-evolving loop in one dependency._
+
+</div>
+
+**Context is the missing layer.** Retrieval answers _what_ happened. OpenContext answers _how_ what happened became what is.
+
+**Unlike memory libs that only retrieve,** OpenContext keeps the _why_ — temporal timelines, belief revision, and provenance.
+
+<div align="center">
 
 <p align="center">
 <a href="./README.md">English</a> · <a href="./README-zh.md">简体中文</a>


### PR DESCRIPTION
## Summary

- **English `README.md`**: replace the existing tagline and description paragraph on the first screen with a four-line rewrite.
- **Chinese `README-zh.md`**: matching Chinese translation.

The four new lines on top of the README are:

1. A one-line pain-point H1 — `Your agent forgets why it made decisions. OpenContext fixes that.`
2. A one-line positioning subtitle — `The context layer for AI agents — a temporal context graph, memory API, and self-evolving loop in one dependency.`
3. A category-defining sentence — `Context is the missing layer. Retrieval answers what happened. OpenContext answers how what happened became what is.`
4. A differentiation line — `Unlike memory libs that only retrieve, OpenContext keeps the why — temporal timelines, belief revision, and provenance.`

## What did NOT change

- `## Benchmarks` / `## 基准测试` sections — original 3-row table untouched.
- `## Features` / `## 特性`, Quick Start, Examples, "Why It Is Different", Architecture, Documentation, Contributing, License — all unchanged.
- No code changes.

`pnpm format` reports `No fixes applied` — only copy was rewritten.

## Test plan

- [ ] Open `README.md` on a fresh tab and confirm the four new lines render above the badge block.
- [ ] Switch to `README-zh.md` and confirm the Chinese translation matches.
- [ ] Scroll past the badges and verify `## Benchmarks` still shows the original 3-row table (LongMemEval-S / LoCoMo-V2 / BEAM @ 10M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)