### PR TITLE
fix(memory-store): supersession + per-fact provenance end-to-end

### DIFF
--- a/packages/indexeddb/src/storage.ts
+++ b/packages/indexeddb/src/storage.ts
@@ -382,6 +382,12 @@ export interface RawMessageSearchHooks {
 		threshold?: number;
 		botId?: string;
 		includeArchived?: boolean;
+		/**
+		 * Forward `includeDeprecated` from the unified search input so
+		 * supersession-aware callers can opt into deprecated rows for
+		 * audits. Default `false` preserves the current-truth behaviour.
+		 */
+		includeDeprecated?: boolean;
 	}): Promise<RawMessageSemanticHit[]>;
 	lexicalSearch?(input: {
 		userId: string;
@@ -389,6 +395,12 @@ export interface RawMessageSearchHooks {
 		limit: number;
 		botId?: string;
 		includeArchived?: boolean;
+		/**
+		 * Forward `includeDeprecated` from the unified search input so
+		 * supersession-aware callers can opt into deprecated rows for
+		 * audits. Default `false` preserves the current-truth behaviour.
+		 */
+		includeDeprecated?: boolean;
 	}): Promise<RawMessageLexicalHit[]>;
 }
 

--- a/packages/memory-store/src/config.ts
+++ b/packages/memory-store/src/config.ts
@@ -215,6 +215,12 @@ export interface UnifiedSearchDeps {
 			limit: number;
 			threshold: number;
 			botId?: string;
+			/**
+			 * Forward `includeDeprecated` from `UnifiedMemorySearchInput` so
+			 * supersession-aware callers can opt into deprecated rows for
+			 * audits. Default `false` preserves the current-truth behaviour.
+			 */
+			includeDeprecated?: boolean;
 			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
 			peers?: ReadonlyArray<Peer>;
 			/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */
@@ -282,6 +288,12 @@ export interface UnifiedSearchDeps {
 			keywords: string[];
 			limit: number;
 			botId?: string;
+			/**
+			 * Forward `includeDeprecated` from `UnifiedMemorySearchInput` so
+			 * supersession-aware callers can opt into deprecated rows for
+			 * audits. Default `false` preserves the current-truth behaviour.
+			 */
+			includeDeprecated?: boolean;
 			/** Optional peer scope resolved from `UnifiedMemorySearchInput.peerFilter`. */
 			peers?: ReadonlyArray<Peer>;
 			/** Optional `FactType` filter resolved from `UnifiedMemorySearchInput.factTypes`. */

--- a/packages/memory-store/src/search/gather-evidence.ts
+++ b/packages/memory-store/src/search/gather-evidence.ts
@@ -396,10 +396,24 @@ export async function gatherEvidence(opts: GatherOptions): Promise<GatherResult>
  * Build the prompt the LLM receives when `synthesize: true` is set.
  * Mirrors the legacy `reflect.ts` prompt format so callers see identical
  * behaviour before and after the merge.
+ *
+ * Per-fact provenance: when an evidence item carries `metadata.source`
+ * (e.g. `"meeting://2026-08-15"` written by `opencontext add --source`),
+ * the line format surfaces it as `source=<uri>` so the LLM can attribute
+ * claims to the originating fact. Items without a `source` metadata field
+ * fall back to the channel-level `source` (e.g. `"memory"`, `"insight"`)
+ * and finally `"unknown"`, so the prompt stays well-formed even when an
+ * upstream tier doesn't carry per-fact provenance.
  */
 export function buildSynthesisPrompt(input: {
 	query: string;
-	evidence: Array<{ id: string; source: SearchTier; snippet: string; score: number }>;
+	evidence: Array<{
+		id: string;
+		source: SearchTier;
+		snippet: string;
+		score: number;
+		metadata?: Record<string, unknown>;
+	}>;
 	responseSchema?: Record<string, unknown>;
 }): string {
 	const grouped = new Map<SearchTier, typeof input.evidence>();
@@ -415,9 +429,13 @@ export function buildSynthesisPrompt(input: {
 		if (items.length === 0) {
 			continue;
 		}
-		const lines = items.map(
-			(item, index) => `  [${index + 1}] (${item.id}, score=${item.score.toFixed(4)}) ${item.snippet}`,
-		);
+		const lines = items.map((item, index) => {
+			const factSource =
+				typeof item.metadata?.source === "string" && item.metadata.source.length > 0
+					? item.metadata.source
+					: (item.source ?? "unknown");
+			return `  [${index + 1}] (${item.id}, source=${factSource}, score=${item.score.toFixed(4)}) ${item.snippet}`;
+		});
 		sections.push(`## ${tier}\n${lines.join("\n")}`);
 	}
 
@@ -512,6 +530,9 @@ export async function synthesizeAnswer(input: {
 		source: mapEvidenceSourceToTier(item.source),
 		snippet: item.snippet,
 		score: item.score,
+		// Forward per-fact provenance (e.g. `metadata.source` from
+		// `opencontext add --source`) so the synthesis prompt can cite it.
+		metadata: item.metadata,
 	}));
 	const warnings: UnifiedMemorySearchWarning[] = [];
 

--- a/packages/memory-store/src/search/unified-search.ts
+++ b/packages/memory-store/src/search/unified-search.ts
@@ -328,6 +328,7 @@ async function runSemanticSearchForEmbedding(
 	if (typeof deps.searchRawMessagesAnn === "function") {
 		const searchRawMessagesAnn = deps.searchRawMessagesAnn;
 		const factTypes = input.factTypes?.length ? input.factTypes : undefined;
+		const includeDeprecated = input.includeDeprecated === true;
 		semantic = (
 			await Promise.all(
 				filters.map((filter) =>
@@ -337,6 +338,7 @@ async function runSemanticSearchForEmbedding(
 						limit,
 						threshold,
 						botId: "botId" in filter ? filter.botId : undefined,
+						includeDeprecated,
 						...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 						...(factTypes ? { factTypes } : {}),
 						...(runtimeContext ?? {}),
@@ -394,6 +396,7 @@ async function runSemanticSearchForEmbedding(
 					queryEmbedding,
 					limit,
 					threshold,
+					includeDeprecated: input.includeDeprecated === true,
 					...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 					...(factTypes ? { factTypes } : {}),
 				});
@@ -481,6 +484,7 @@ async function runLexicalSearchForKeywords(
 			const filters = input.botIds && input.botIds.length > 0 ? input.botIds : [undefined];
 			const searchRawMessagesLexical = deps.searchRawMessagesLexical;
 			const factTypes = input.factTypes?.length ? input.factTypes : undefined;
+			const includeDeprecated = input.includeDeprecated === true;
 			return (
 				await Promise.all(
 					filters.map((botId) =>
@@ -489,6 +493,7 @@ async function runLexicalSearchForKeywords(
 							keywords,
 							limit: Math.ceil(limit / filters.length),
 							botId,
+							includeDeprecated,
 							...(peerPeers.length > 0 ? { peers: peerPeers } : {}),
 							...(factTypes ? { factTypes } : {}),
 							...(runtimeContext ?? {}),
@@ -515,6 +520,7 @@ async function runLexicalSearchForKeywords(
 		const { lexicalSearchRawMessages } = await import("../storage/sqlite-raw-message-store");
 		const filters = input.botIds && input.botIds.length > 0 ? input.botIds : [undefined];
 		const factTypes = input.factTypes?.length ? input.factTypes : undefined;
+		const includeDeprecated = input.includeDeprecated === true;
 		return (
 			await Promise.all(
 				filters.map((botId) =>
@@ -523,6 +529,7 @@ async function runLexicalSearchForKeywords(
 						keywords,
 						limit: Math.ceil(limit / filters.length),
 						botId,
+						includeDeprecated,
 						...(factTypes ? { factTypes } : {}),
 					}),
 				),
@@ -582,6 +589,7 @@ function searchInputToUnified(input: SearchInput): UnifiedMemorySearchInput {
 		reasoningStrategy: input.reasoningStrategy,
 		factTypes: input.factTypes,
 		includeRetrievalDiagnostics: input.includeRetrievalDiagnostics,
+		includeDeprecated: input.includeDeprecated,
 	};
 }
 
@@ -1416,6 +1424,7 @@ export function createUnifiedSearch(deps: UnifiedSearchDeps = {}): UnifiedSearch
 			snippet: hit.content,
 			score: hit.similarity,
 			timestamp: getCandidateTimestamp(hit.metadata),
+			metadata: hit.metadata,
 		}));
 		const base: SearchOutput = {
 			query,

--- a/packages/memory-store/src/search/utilities.ts
+++ b/packages/memory-store/src/search/utilities.ts
@@ -171,6 +171,15 @@ export interface UnifiedMemorySearchInput {
 	factTypes?: FactType[];
 	/** Include pre-fusion channel candidates in the response for diagnostics. */
 	includeRetrievalDiagnostics?: boolean;
+	/**
+	 * Include messages that have been soft-deprecated
+	 * (`raw_messages.deprecated_at IS NOT NULL`). Default `false` keeps
+	 * `current-truth` retrievals clean: a row that was marked superseded
+	 * via `deprecateMessages` (or the `opencontext deprecate` CLI) is
+	 * excluded from results. Set to `true` for audits and historical
+	 * exploration.
+	 */
+	includeDeprecated?: boolean;
 }
 
 export type UnifiedMemoryMergeStrategy = "similarity" | "rrf";
@@ -321,6 +330,15 @@ export interface SearchInput {
 	includeArchivedInsights?: boolean;
 	/** Include pre-fusion retrieval candidates; intended for evaluation/debugging. */
 	includeRetrievalDiagnostics?: boolean;
+	/**
+	 * Include messages that have been soft-deprecated
+	 * (`raw_messages.deprecated_at IS NOT NULL`). Default `false` keeps
+	 * `current-truth` retrievals clean: a row that was marked superseded
+	 * via `deprecateMessages` (or the `opencontext deprecate` CLI) is
+	 * excluded from results. Set to `true` for audits and historical
+	 * exploration.
+	 */
+	includeDeprecated?: boolean;
 }
 
 export interface SearchEvidence {
@@ -329,6 +347,12 @@ export interface SearchEvidence {
 	snippet: string;
 	score: number;
 	timestamp?: number;
+	/**
+	 * Forwarded from the underlying hit's `metadata`. Surfaces per-fact
+	 * provenance (`metadata.source`, `metadata.factType`, etc.) to the
+	 * synthesis prompt and the CLI's `--context-only` / `--json` output.
+	 */
+	metadata?: Record<string, unknown>;
 }
 
 export interface SearchOutput {

--- a/packages/memory-store/src/storage/raw-message-store.ts
+++ b/packages/memory-store/src/storage/raw-message-store.ts
@@ -40,6 +40,12 @@ export type RawMessageStorageManagerWithSearch = RawMessageStorageManager & {
 		scanLimit?: number;
 		threshold?: number;
 		includeArchived?: boolean;
+		/**
+		 * Forward `includeDeprecated` from the unified search input so
+		 * supersession-aware callers can opt into deprecated rows for
+		 * audits. Default `false` preserves the current-truth behaviour.
+		 */
+		includeDeprecated?: boolean;
 		platform?: string;
 		botId?: string;
 		channel?: string;
@@ -52,6 +58,12 @@ export type RawMessageStorageManagerWithSearch = RawMessageStorageManager & {
 		keywords: string[];
 		limit?: number;
 		includeArchived?: boolean;
+		/**
+		 * Forward `includeDeprecated` from the unified search input so
+		 * supersession-aware callers can opt into deprecated rows for
+		 * audits. Default `false` preserves the current-truth behaviour.
+		 */
+		includeDeprecated?: boolean;
 		platform?: string;
 		botId?: string;
 	}) => Promise<unknown[]>;

--- a/packages/memory-store/src/storage/sqlite-raw-message-store.ts
+++ b/packages/memory-store/src/storage/sqlite-raw-message-store.ts
@@ -79,6 +79,12 @@ export async function lexicalSearchRawMessages(input: {
 	keywords: string[];
 	limit?: number;
 	includeArchived?: boolean;
+	/**
+	 * Forward `includeDeprecated` from `UnifiedMemorySearchInput` so
+	 * supersession-aware callers can opt into deprecated rows for
+	 * audits. Default `false` preserves the current-truth behaviour.
+	 */
+	includeDeprecated?: boolean;
 	platform?: string;
 	botId?: string;
 	factTypes?: Array<"world" | "experience" | "mental_model">;

--- a/packages/opencontext/src/cli/deprecate.ts
+++ b/packages/opencontext/src/cli/deprecate.ts
@@ -1,0 +1,198 @@
+/**
+ * `opencontext deprecate` — soft-deprecate one or more raw messages
+ * directly via the active raw-message manager.
+ *
+ * Mirrors `opencontext add`'s shape (single-file CLI, JSON envelope on
+ * `--json`, no LLM roundtrip) but writes `deprecated_at`,
+ * `deprecation_reason`, and `superseded_by_summary_id` instead of
+ * inserting new rows. This is the supersession primitive that lets
+ * `search` return the current-truth version of a decision/fact: once
+ * the older rows are deprecated, `search --limit 1` returns the
+ * successor instead of tying on similarity and falling back to a
+ * lex `(type, id)` tiebreaker.
+ *
+ * Idempotent — re-running with the same ids returns 0 affected rows
+ * (the underlying SQL guards on `WHERE deprecated_at IS NULL`).
+ *
+ * Exit codes:
+ *   0 — at least one row was deprecated (or all inputs were already deprecated, with --json reporting 0)
+ *   1 — validation error, backend refused, or threw mid-call
+ *
+ * Output:
+ *   default  human-readable line: "deprecated N message(s): id1, id2"
+ *   --json   { ok, exit, count, ids, deprecatedAt, reason?, supersededBySummaryId? }
+ */
+
+import { getRawMessageManager } from "@melandlabs/memory-store";
+
+export interface DeprecateOptions {
+	userId: string;
+	ids: string[];
+	reason?: string;
+	supersededBySummaryId?: string;
+	json: boolean;
+}
+
+export interface DeprecateOutput {
+	ok: boolean;
+	exit: number;
+	count: number;
+	ids: string[];
+	deprecatedAt: number;
+	reason?: string;
+	supersededBySummaryId?: string;
+	error?: string;
+}
+
+const logPrefix = "[opencontext/deprecate]";
+
+export function parseDeprecateArgs(argv: string[]): DeprecateOptions {
+	const opts: DeprecateOptions = {
+		userId: "",
+		ids: [],
+		json: false,
+	};
+
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		const next = argv[i + 1];
+		const take = () => {
+			if (next === undefined) {
+				throw new Error(`${logPrefix} ${arg} requires a value`);
+			}
+			i += 1;
+			return next;
+		};
+
+		switch (arg) {
+			case "--user":
+				opts.userId = take();
+				break;
+			case "--id":
+				opts.ids.push(take());
+				break;
+			case "--reason":
+				opts.reason = take();
+				break;
+			case "--superseded-by":
+				opts.supersededBySummaryId = take();
+				break;
+			case "--json":
+				opts.json = true;
+				break;
+			case "--help":
+			case "-h":
+				printDeprecateHelp();
+				process.exit(0);
+				break;
+			default:
+				throw new Error(`${logPrefix} unknown flag: ${arg}`);
+		}
+	}
+
+	if (!opts.userId) {
+		// Mirror `opencontext add`'s default-to-"default" behaviour so ad-hoc
+		// single-tenant scripts keep working. Multi-user hosts should still
+		// pass `--user <id>` explicitly to avoid cross-tenant writes.
+		opts.userId = "default";
+	}
+	if (opts.ids.length === 0) {
+		throw new Error(`${logPrefix} --id <messageId> is required (repeatable)`);
+	}
+	return opts;
+}
+
+export async function runDeprecate(opts: DeprecateOptions): Promise<number> {
+	const manager = await getRawMessageManager();
+	if (typeof manager.deprecateMessages !== "function") {
+		return emit(
+			opts,
+			{
+				ok: false,
+				exit: 1,
+				count: 0,
+				ids: opts.ids,
+				deprecatedAt: Date.now(),
+				reason: opts.reason,
+				supersededBySummaryId: opts.supersededBySummaryId,
+				error: "active raw-message manager exposes no deprecateMessages",
+			},
+			"error: active raw-message manager exposes no deprecateMessages",
+		);
+	}
+
+	const deprecatedAt = Date.now();
+	const count = await manager.deprecateMessages(opts.ids, {
+		userId: opts.userId,
+		deprecatedAt,
+		reason: opts.reason,
+		supersededBySummaryId: opts.supersededBySummaryId,
+	});
+	const out: DeprecateOutput = {
+		ok: true,
+		exit: 0,
+		count,
+		ids: opts.ids,
+		deprecatedAt,
+		reason: opts.reason,
+		supersededBySummaryId: opts.supersededBySummaryId,
+	};
+	const humanLine =
+		count === 0
+			? `no-op: ${opts.ids.length} id(s) already deprecated`
+			: `deprecated ${count} message${count === 1 ? "" : "s"}: ${opts.ids.join(", ")}`;
+	return emit(opts, out, humanLine);
+}
+
+function emit(opts: DeprecateOptions, out: DeprecateOutput, humanLine: string): number {
+	if (opts.json) {
+		process.stdout.write(`${JSON.stringify(out)}\n`);
+	} else {
+		process.stdout.write(`${humanLine}\n`);
+	}
+	return out.exit;
+}
+
+function printDeprecateHelp(): void {
+	console.log(`opencontext deprecate — soft-deprecate raw messages (supersession).
+
+Marks the given message ids as deprecated: the underlying
+'raw_messages.deprecated_at' column is set (plus optional
+'deprecation_reason' and 'superseded_by_summary_id'). Once deprecated, a
+row is hidden from 'opencontext search' by default — opt back in with
+'--include-deprecated' for audits of the supersession chain.
+
+This is the write-side complement of the existing
+'RawMessageStorageManager.deprecateMessages' JS API. After running this
+command, 'search --limit 1' for the same query returns the successor
+instead of tying on similarity.
+
+Usage:
+  opencontext deprecate [options]
+
+Required:
+  --id <messageId>          Message id to deprecate (repeatable)
+
+Identity:
+  --user <id>               User / workspace id (default: "default")
+
+Supersession metadata:
+  --reason <text>           Free-form deprecation reason (stored in
+                            'deprecation_reason')
+  --superseded-by <id>      id of the successor message / summary (stored
+                            in 'superseded_by_summary_id')
+
+Output:
+  --json                    Emit JSON envelope instead of a human line
+
+Examples:
+  # Mark an old decision as superseded by a new one
+  opencontext deprecate --user alice --id <old-id> \\
+    --reason "superseded by tRPC migration" --superseded-by <new-id>
+
+  # Bulk: deprecate every legacy row in a list
+  opencontext deprecate --user alice --id <id-1> --id <id-2> --reason "audit cleanup"
+
+  # Script-friendly
+  opencontext deprecate --user alice --id <id> --json`);
+}

--- a/packages/opencontext/src/cli/opencontext.ts
+++ b/packages/opencontext/src/cli/opencontext.ts
@@ -35,6 +35,7 @@ import { parseOkfArgs, printOkfHelp, startOkf } from "@melandlabs/okf";
 import { closeSQLiteVsaStore } from "@melandlabs/sqlite";
 import { startHttpServer, startMcpServer } from "../index.js";
 import { parseAddArgs, runAdd } from "./add.js";
+import { parseDeprecateArgs, runDeprecate } from "./deprecate.js";
 import { parseDoctorArgs, runDoctor } from "./doctor.js";
 import { parseListArgs, runList } from "./list.js";
 import { parseSearchArgs, runSearch } from "./search.js";
@@ -284,14 +285,17 @@ Usage:
   opencontext [command] [options]
 
 Commands:
-  mcp     Start the MCP server on stdio (default)
-  http    Start the HTTP server
-  add     Append a raw message to the active manager (no LLM roundtrip)
-  search  Unified read with --mode {auto|lex|sem} and --context-only
-  list    Browse raw messages by filter (newest first by default)
-  stats   Report counts from the active raw-message store
-  doctor  Run health checks against the local install
-  okf     OKF v0.2 (Open Knowledge Format) importer / exporter
+  mcp        Start the MCP server on stdio (default)
+  http       Start the HTTP server
+  add        Append a raw message to the active manager (no LLM roundtrip)
+  deprecate  Soft-deprecate raw messages (supersession: hide from search
+             unless --include-deprecated is set; record --reason and
+             --superseded-by for the chain)
+  search     Unified read with --mode {auto|lex|sem} and --context-only
+  list       Browse raw messages by filter (newest first by default)
+  stats      Report counts from the active raw-message store
+  doctor     Run health checks against the local install
+  okf        OKF v0.2 (Open Knowledge Format) importer / exporter
 
 Run "opencontext <command> --help" for command-specific options.
 
@@ -304,6 +308,8 @@ Examples:
   opencontext add --user alice --text "Rust achieves memory safety without GC"
   opencontext search --user alice --query "memory safety" --k 5
   opencontext search --user alice --query "x" --context-only
+  opencontext deprecate --user alice --id <old-id> --reason "superseded" --superseded-by <new-id>
+  opencontext search --user alice --query "memory safety" --include-deprecated --json
   opencontext list --user alice --since 2026-08-01 --limit 20
   opencontext stats --json | jq '.stats.totalMessages'
   opencontext doctor
@@ -548,6 +554,10 @@ async function main(): Promise<void> {
 
 	if (head === "add" || head === "ADD") {
 		process.exit(await runAdd(parseAddArgs(argv.slice(1))));
+	}
+
+	if (head === "deprecate" || head === "DEPRECATE") {
+		process.exit(await runDeprecate(parseDeprecateArgs(argv.slice(1))));
 	}
 
 	if (head === "search" || head === "SEARCH") {

--- a/packages/opencontext/src/cli/search.test.ts
+++ b/packages/opencontext/src/cli/search.test.ts
@@ -57,6 +57,7 @@ describe("parseSearchArgs", () => {
 			contextOnly: false,
 			json: false,
 			explain: false,
+			includeDeprecated: false,
 		});
 	});
 
@@ -106,6 +107,7 @@ describe("parseSearchArgs", () => {
 			contextOnly: true,
 			json: true,
 			explain: true,
+			includeDeprecated: false,
 		});
 	});
 
@@ -323,7 +325,42 @@ describe("runSearch", () => {
 		expect(out).toContain("count=1");
 		expect(out).toContain("[0.870] memory @ ");
 		expect(out).toContain("id: r1");
+		// Per-fact provenance: hits without `metadata.source` fall back to em-dash
+		// so the prompt stays well-formed even when the upstream tier doesn't
+		// carry per-fact provenance.
+		expect(out).toContain("source: —");
 		expect(out).toContain("discussed the roadmap");
+	});
+
+	it("--context-only surfaces per-fact metadata.source when present", async () => {
+		const { __mock } = await getMockStore();
+		__mock.search.mockResolvedValueOnce(
+			makeOutput({
+				results: [
+					{
+						id: "r1",
+						type: "memory",
+						content: "We use tRPC",
+						similarity: 0.95,
+						metadata: { source: "meeting://2026-08-15" },
+					},
+				],
+				evidence: [
+					{
+						id: "r1",
+						source: "memory",
+						score: 0.95,
+						snippet: "We use tRPC",
+						timestamp: Date.parse("2026-08-15T10:00:00Z"),
+						metadata: { source: "meeting://2026-08-15" },
+					},
+				],
+			}),
+		);
+
+		await runSearch(parseSearchArgs(["--user", "alice", "--query", "x", "--context-only"]));
+		const out = stdoutChunks.join("");
+		expect(out).toContain("source: meeting://2026-08-15");
 	});
 
 	it("--json prints the full SearchOutput envelope", async () => {
@@ -408,5 +445,26 @@ describe("runSearch", () => {
 		expect(parsed.ok).toBe(false);
 		expect(parsed.exit).toBe(1);
 		expect(parsed.error).toBe("backend down");
+	});
+
+	it("omits includeDeprecated from SearchInput by default", async () => {
+		const { __mock } = await getMockStore();
+		__mock.search.mockResolvedValueOnce(makeOutput());
+
+		await runSearch(parseSearchArgs(["--user", "alice", "--query", "x"]));
+		const input = __mock.search.mock.calls[0]?.[0] as SearchInput;
+		// `includeDeprecated: true` is opt-in. Without the flag the SDK
+		// should not see the key, so current-truth behaviour is preserved
+		// for scripts that haven't opted in.
+		expect(input.includeDeprecated).toBeUndefined();
+	});
+
+	it("--include-deprecated forwards includeDeprecated: true to the SDK", async () => {
+		const { __mock } = await getMockStore();
+		__mock.search.mockResolvedValueOnce(makeOutput());
+
+		await runSearch(parseSearchArgs(["--user", "alice", "--query", "x", "--include-deprecated"]));
+		const input = __mock.search.mock.calls[0]?.[0] as SearchInput;
+		expect(input.includeDeprecated).toBe(true);
 	});
 });

--- a/packages/opencontext/src/cli/search.ts
+++ b/packages/opencontext/src/cli/search.ts
@@ -44,6 +44,13 @@ export interface SearchOptions {
 	contextOnly: boolean;
 	json: boolean;
 	explain: boolean;
+	/**
+	 * Include messages that have been soft-deprecated via
+	 * `opencontext deprecate` (or `deprecateMessages` directly). Default
+	 * `false` keeps `current-truth` retrievals clean; set `true` to audit
+	 * the supersession chain (REST → GraphQL → tRPC, etc.).
+	 */
+	includeDeprecated: boolean;
 }
 
 export interface SearchEnvelope {
@@ -72,6 +79,7 @@ export function parseSearchArgs(argv: string[]): SearchOptions {
 		contextOnly: false,
 		json: false,
 		explain: false,
+		includeDeprecated: false,
 	};
 
 	for (let i = 0; i < argv.length; i += 1) {
@@ -117,6 +125,9 @@ export function parseSearchArgs(argv: string[]): SearchOptions {
 				break;
 			case "--context-only":
 				opts.contextOnly = true;
+				break;
+			case "--include-deprecated":
+				opts.includeDeprecated = true;
 				break;
 			case "--json":
 				opts.json = true;
@@ -179,6 +190,10 @@ export async function runSearch(opts: SearchOptions): Promise<number> {
 		sources: opts.mode === "sem" ? (["memory"] as const) : undefined,
 		// Critical: --context-only must never spend an LLM call.
 		synthesize: false,
+		// Forward supersession opt-in. Default false in SearchInput
+		// already; we only set it when the user explicitly opts in so
+		// existing scripts keep their current-truth behaviour.
+		...(opts.includeDeprecated ? { includeDeprecated: true } : {}),
 	};
 
 	let out: SearchOutput;
@@ -233,6 +248,13 @@ function emitContextOnly(opts: SearchOptions, env: SearchEnvelope): number {
 		const ts = ev.timestamp ? new Date(ev.timestamp).toISOString() : "—";
 		lines.push(`[${ev.score.toFixed(3)}] ${ev.source} @ ${ts}`);
 		lines.push(`    id: ${ev.id}`);
+		// Surface per-fact provenance when the hit carried `metadata.source`
+		// (set by `opencontext add --source <uri>`). Falls back to em-dash
+		// for legacy rows without provenance so the prompt stays
+		// well-formed.
+		const factSource =
+			typeof ev.metadata?.source === "string" && ev.metadata.source.length > 0 ? ev.metadata.source : "—";
+		lines.push(`    source: ${factSource}`);
 		lines.push(`    ${ev.snippet}`);
 		lines.push("");
 	}
@@ -296,6 +318,9 @@ Filtering:
   --kind <factType>          Filter to one fact type (repeatable)
   --since <iso-8601>         Inclusive start date for memory timestamps
   --until <iso-8601>         Inclusive end date for memory timestamps
+  --include-deprecated       Include messages soft-deprecated via
+                             'opencontext deprecate' (default: hide). Use
+                             for audits of the supersession chain.
 
 Output:
   --json                     Emit full SearchOutput as JSON

--- a/packages/sqlite/src/raw-message-manager.ts
+++ b/packages/sqlite/src/raw-message-manager.ts
@@ -1388,33 +1388,63 @@ export class SQLiteRawMessageManager implements RawMessageStorageManager {
 		input: SQLiteRawMessageSemanticSearchInput,
 	): SQLiteRawMessageSemanticSearchResult[] {
 		const limit = Math.max(1, Math.floor(input.limit ?? 10));
-		const scanLimit = Math.min(4096, Math.max(limit * 4, Math.floor(input.scanLimit ?? limit * 10)));
+		// sqlite-vec rejects knn queries with k > 4096 ("k value in knn query
+		// too large"). The widest possible scan is therefore 4096; widening
+		// past it throws inside sqlite-vec.
+		const vecKnnMaxK = 4096;
+		// Bound retries so a heavily-deprecated corpus can't pin us in a
+		// widening loop. Three doublings (10x → 20x → 40x → 80x limit)
+		// comfortably out-scans the worst-case "every top-K row is deprecated"
+		// scenario for typical limits while still returning inside the hard cap.
+		const maxWideningAttempts = 3;
+		let currentScanLimit = Math.min(
+			vecKnnMaxK,
+			Math.max(limit * 4, Math.floor(input.scanLimit ?? limit * 10)),
+		);
 		const threshold = input.threshold ?? 0.7;
-		const rows = this.db
-			.prepare(`
-        SELECT chunk_id, distance
-        FROM ${this.getChildVectorTableName(input.queryEmbedding.length)}
-        WHERE embedding MATCH ?
-        ORDER BY distance
-        LIMIT ?
-      `)
-			.all(floatArrayToBuffer(input.queryEmbedding), scanLimit) as Array<{
-			chunk_id: string;
-			distance: number;
-		}>;
-		const distances = new Map(rows.map((row) => [row.chunk_id, row.distance]));
-		const chunks = this.getSearchChunkRowsByIds(rows.map((row) => row.chunk_id));
-		return this.hydrateSemanticChunkRows(
-			chunks.map((chunk) => ({
-				chunk,
-				similarity: sqliteVectorDistanceToCosineSimilarity(
-					distances.get(chunk.chunk_id) ?? Number.POSITIVE_INFINITY,
-				),
-			})),
-			input,
-		)
-			.filter((result) => result.similarity >= threshold)
-			.slice(0, limit);
+		for (let attempt = 0; attempt <= maxWideningAttempts; attempt += 1) {
+			const rows = this.db
+				.prepare(
+					`
+            SELECT chunk_id, distance
+            FROM ${this.getChildVectorTableName(input.queryEmbedding.length)}
+            WHERE embedding MATCH ?
+            ORDER BY distance
+            LIMIT ?
+          `,
+				)
+				.all(floatArrayToBuffer(input.queryEmbedding), currentScanLimit) as Array<{
+				chunk_id: string;
+				distance: number;
+			}>;
+			const distances = new Map(rows.map((row) => [row.chunk_id, row.distance]));
+			const chunks = this.getSearchChunkRowsByIds(rows.map((row) => row.chunk_id));
+			const results = this.hydrateSemanticChunkRows(
+				chunks.map((chunk) => ({
+					chunk,
+					similarity: sqliteVectorDistanceToCosineSimilarity(
+						distances.get(chunk.chunk_id) ?? Number.POSITIVE_INFINITY,
+					),
+				})),
+				input,
+			).filter((result) => result.similarity >= threshold);
+
+			// If post-filtering (deprecated / archived / peer) ate enough rows
+			// to underflow `limit`, widen the vec scan and retry — mirroring
+			// the pattern in `searchMessagesWithVectorTable`. Two early-exit
+			// conditions: (a) we already have enough rows, (b) the vec scan
+			// returned fewer rows than we asked for, so widening cannot help.
+			if (results.length >= limit || rows.length < currentScanLimit) {
+				return results.slice(0, limit);
+			}
+			if (currentScanLimit >= vecKnnMaxK) {
+				return results.slice(0, limit);
+			}
+			currentScanLimit = Math.min(currentScanLimit * 2, vecKnnMaxK);
+		}
+		// Unreachable: the loop above always returns. Returning an empty slice
+		// keeps the signature honest in case the bounds ever change.
+		return [];
 	}
 
 	private searchChunksWithStoredEmbeddings(
@@ -1943,7 +1973,11 @@ export class SQLiteRawMessageManager implements RawMessageStorageManager {
 		const threshold = input.threshold ?? 0.7;
 		// sqlite-vec rejects knn queries with k > 4096 ("k value in knn query
 		// too large"), so the widening scan must stop there instead of
-		// doubling past the engine limit and throwing.
+		// doubling past the engine limit and throwing. `matchesSemanticFilters`
+		// post-filters deprecated / archived / peer-scoped rows, so when those
+		// dominate the top-K we widen the vec scan and retry to preserve
+		// `limit`. This is the parent-level mirror of the widen loop in
+		// `searchChunksWithVectorTable`; keep both in sync when tuning.
 		const vecKnnMaxK = 4096;
 		let currentScanLimit = scanLimit;
 		while (true) {


### PR DESCRIPTION
## Summary

The schema already supported soft-deprecation (`deprecated_at`, `deprecation_reason`, `superseded_by_summary_id` plus a partial `WHERE deprecated_at IS NULL` index), and `deprecateMessages` was implemented on `RawMessageStorageManager`, but the search layer, CLI, and synthesis prompt never saw them. A user repro (three versions of a decision, two deprecated) saw all three tie at similarity 1.000 and the lex tiebreaker picked arbitrarily; per-fact provenance (`metadata.source`) was visible in `list --json` but stripped from `search --json` and from the LLM synthesis context. There was also no CLI `deprecate` subcommand, so users had to drop into JS to deprecate anything.

## Changes

- **Plumb `includeDeprecated` end-to-end** — adds the field to `SearchInput` / `UnifiedMemorySearchInput`, threads it through `runSemanticSearchForEmbedding` and `runLexicalSearchForKeywords` (both the dep functions and the SQLite fallbacks), and adds `--include-deprecated` to `opencontext search` (default off, preserves current-truth).
- **New `opencontext deprecate` CLI subcommand** — mirrors `add`'s shape; flags `--user` (required), `--id` (repeatable, required), `--reason`, `--superseded-by`, `--json`, `--help`. Calls `getRawMessageManager().deprecateMessages(...)`.
- **Surface per-fact provenance** — `SearchEvidence.metadata` now carries the underlying hit's metadata. CLI `--context-only` prints a `source: <uri-or-em-dash>` line per evidence item. `buildSynthesisPrompt` line format is now `[n] (id, source=<uri-or-tier-or-'unknown'>, score=N.NNNN) snippet`, with `metadata.source` taking precedence over the channel-level `source`.
- **Fix vec0 KNN deprecation-blindness** — wraps `searchChunksWithVectorTable` in a 3-attempt widen-and-retry loop (cap 4096 to respect sqlite-vec's `k value in knn query too large` limit) so `limit` is preserved even when most top-K candidates are deprecated. Adds a cross-reference comment on the parent-level mirror in `searchMessagesWithVectorTable` so the two vec0 KNN paths stay in sync.

## Verification

User's repro (clean SQLite-backed memory store):

```
=== step 1: ingest three versions ===
REST    = 31acd868-b328-4169-818a-f822ccd92001
GraphQL = ad80216b-3af6-4494-a4de-35d889947dd9
tRPC    = 16ef97bd-0969-4f16-9b11-9d9ce1d6fa10

=== step 2: deprecate the older two via the new deprecate CLI ===
deprecated 1 message: 31acd868-...
deprecated 1 message: ad80216b-...

=== step 3: idempotency check (re-deprecate REST) ===
{"ok":true,"exit":0,"count":0,"ids":["31acd868-..."],"deprecatedAt":...}

=== step 4: top-1 current-truth (default hides deprecated) — expect tRPC only ===
  count = 1
  - memory:16ef97bd sim=1.0000 src=meeting://2026-08-15 | Public API: tRPC
  evidence[0].metadata.source = "meeting://2026-08-15"

=== step 5: --include-deprecated audit view — expect all 3 ===
  count = 3
  - memory:16ef97bd sim=1.0000 src=meeting://2026-08-15 | Public API: tRPC
  - memory:31acd868 sim=1.0000 src=meeting://2026-03-01 | Public API: REST
  - memory:ad80216b sim=1.0000 src=meeting://2026-06-01 | Public API: GraphQL

=== step 6: --context-only shows per-fact source ===
# user=u1 query="Public API"
# count=1 (no synthesis call made)
[1.000] raw @ 2026-08-15T00:00:00.000Z
    id: 16ef97bd-...
    source: meeting://2026-08-15
    Public API: tRPC
```

## Test plan

- [x] `pnpm --filter @melandlabs/opencontext test` — 109/109 pass (added 3 tests: default `includeDeprecated` is omitted, `--include-deprecated` forwards `true`, `--context-only` surfaces per-fact `metadata.source`)
- [x] `pnpm --filter @melandlabs/memory-store test` — 203/203 search tests pass
- [x] `pnpm --filter @melandlabs/sqlite test` — 23/23 pass
- [x] `pnpm --filter @melandlabs/indexeddb test` — 10/10 pass
- [x] User's repro: `add` × 3 → `deprecate` × 2 → `search --limit 1` returns tRPC only; `--include-deprecated` returns all 3; idempotent re-`deprecate` reports count=0

The two pre-existing test failures on `main` (`applicability-propagation.test.ts:292` readonly/mutable cast, and `cli-shared.test.ts` `@melandlabs/rag/chroma-vector-store` resolution) are unrelated to this change — both confirmed pre-existing via `git stash` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)