### PR TITLE
chore: republish @melandlabs/opencontext with @melandlabs/workspace dep

### DIFF
--- a/.changeset/republish-opencontext-with-workspace-dep.md
+++ b/.changeset/republish-opencontext-with-workspace-dep.md
@@ -1,0 +1,5 @@
+---
+"@melandlabs/opencontext": patch
+---
+
+Republish `@melandlabs/opencontext` so the `0.9.0` tarball picks up the `@melandlabs/workspace` runtime dependency that PR #38 wired into the CLI (`opencontext workspace update|search|list`). Without this republish, `pnpm dlx @melandlabs/opencontext@0.9.0 workspace …` fails with `Cannot find package '@melandlabs/workspace'`.


### PR DESCRIPTION
## What

A patch-level `.changeset/` entry that bumps `@melandlabs/opencontext` so the next release publishes `0.9.1` with the `@melandlabs/workspace` dependency that PR #38 wired into the CLI.

## Why

PR #38 added `opencontext workspace update|search|list` and listed `@melandlabs/workspace` in `packages/opencontext/package.json`, but its changesets only listed `@melandlabs/workspace` as a bump target. The release workflow saw `@melandlabs/opencontext@0.9.0` already published and skipped it, so the public tarball does not declare the new dep.

Result: `pnpm dlx @melandlabs/opencontext@0.9.0 workspace …` fails with `Cannot find package '@melandlabs/workspace'` because the dynamic `import("@melandlabs/workspace/cli")` in `packages/opencontext/src/cli/opencontext.ts` can't resolve.

## Verification

After merge, the release workflow will publish `0.9.1`. `pnpm dlx @melandlabs/opencontext@0.9.1 workspace --help` should print the subcommand help.