### PR TITLE
chore(release): bump @melandlabs/opencontext to 0.9.1

### DIFF
--- a/packages/opencontext/CHANGELOG.md
+++ b/packages/opencontext/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @melandlabs/opencontext
 
+## 0.9.1
+
+### Patch Changes
+
+- Republish to declare `@melandlabs/workspace` as a runtime dependency so `opencontext workspace update|search|list` resolves on a fresh `pnpm dlx @melandlabs/opencontext@latest` install.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/opencontext/package.json
+++ b/packages/opencontext/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@melandlabs/opencontext",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"type": "module",
 	"description": "OpenContext — single-package facade that bundles the contracts, memory-store, retrieval, loop engine, and agent runtime. Install once, get every capability.",
 	"main": "./dist/index.js",


### PR DESCRIPTION
## What

Bumps `@melandlabs/opencontext` from `0.9.0` to `0.9.1` and adds a patch-level CHANGELOG entry.

## Why

The release workflow at `.github/workflows/release.yml` runs `pnpm changeset publish --no-git-tag` directly without first invoking `pnpm changeset version`, so the package.json `version` field is never auto-bumped. To publish a new iteration, the version field must be bumped by hand on `main`.

`0.9.1` is needed because PR #38 wired `opencontext workspace update|search|list` into the main bin and added `@melandlabs/workspace` as a runtime dep, but did not bump the opencontext version. The release workflow that ran after PR #38 saw `0.9.0` already on npm and skipped publishing, so `pnpm dlx @melandlabs/opencontext@0.9.0 workspace …` fails with `Cannot find package '@melandlabs/workspace'` (dynamic import at `packages/opencontext/src/cli/opencontext.ts:39`).

## Verification

After merge, the release workflow publishes 0.9.1. `pnpm dlx @melandlabs/opencontext@0.9.1 workspace --help` should print the subcommand help.