### PR TITLE
chore(workspace): expose `workspace` bin + add @melandlabs/ai-rag dep

### DIFF
--- a/packages/opencontext/CHANGELOG.md
+++ b/packages/opencontext/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @melandlabs/opencontext
 
+## 0.10.0
+
+### Minor Changes
+
+- Add `@melandlabs/workspace` as a runtime dependency so `opencontext workspace update|search|list` resolves on a fresh install. The workspace subcommand delegates to `@melandlabs/workspace@^0.2.0`, which exposes its own `workspace` bin for direct invocation as well.
+- Bump `@melandlabs/workspace` to 0.2.0 (adds `workspace` bin, adds `@melandlabs/ai-rag` dep so the cross-file strategy works on a standalone install).
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/opencontext/package.json
+++ b/packages/opencontext/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@melandlabs/opencontext",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"type": "module",
 	"description": "OpenContext — single-package facade that bundles the contracts, memory-store, retrieval, loop engine, and agent runtime. Install once, get every capability.",
 	"main": "./dist/index.js",
@@ -26,7 +26,7 @@
 		"@melandlabs/integrations": "^0.3.0",
 		"@melandlabs/okf": "^0.3.3",
 		"@melandlabs/security": "^0.3.0",
-		"@melandlabs/workspace": "^0.1.0",
+		"@melandlabs/workspace": "^0.2.0",
 		"@modelcontextprotocol/sdk": "^1.25.3",
 		"abort-controller": "^3.0.0",
 		"agentkeepalive": "^4.6.0",

--- a/packages/workspace/CHANGELOG.md
+++ b/packages/workspace/CHANGELOG.md
@@ -1,0 +1,18 @@
+# @melandlabs/workspace
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial public release.
+- CLI: `opencontext workspace update|search|list` (via the `@melandlabs/opencontext` facade) plus `workspace` bin for direct invocation after this release.
+- Storage: reuses the `~/.opencontext/memory/store.db` SQLite schema from `@melandlabs/memory-store`.
+- New tables: `workspace_resources`, `workspace_resource_versions`, `workspace_chunks` + `workspace_chunks_fts`, `workspace_reference_edges`, `workspace_jobs`, and per-dim vec0 child tables (`workspace_chunks_vec_d{384,1536}`).
+- Search strategies: lexical (FTS5 MATCH), semantic (sqlite-vec KNN with widen-and-retry), hybrid (RRF k=60), cross-file (hybrid + cites-edge BFS up to 2 hops).
+- Multi-format parsers: `.md` / `.markdown` / `.txt` pass-through, `.pdf` / `.docx` / `.pages` via `@melandlabs/rag` parsers, `.xlsx` / `.xls` / `.numbers` via SheetJS (`.numbers` first converted with macOS `textutil -convert xlsx`).
+- Cross-file edges: extracted from raw Markdown links via `buildGraphFromDir` AND from markdown links found inside parsed bodies of non-`.md` files.
+- Local embeddings by default: `EMBEDDING_PROVIDER=local` (`Xenova/all-MiniLM-L6-v2`, 384 dims) so demos run offline without `OPENROUTER_API_KEY`.
+
+### Patch Changes
+
+- `--db-path` is honored by every subcommand (`update`, `search`, `list`); previously the flag was parsed but never threaded through to `getSQLiteWorkspaceStore`, so the CLI silently used `~/.opencontext/memory/store.db` regardless of the override.

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -6,6 +6,9 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"bin": {
+		"workspace": "./dist/cli.js"
+	},
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
@@ -35,6 +38,7 @@
 	"description": "OpenContext · workspace module. Provides project-level indexing, hybrid retrieval, and cross-file reference edges over a project workspace.",
 	"keywords": ["opencontext", "project-context", "hybrid-search", "rag"],
 	"dependencies": {
+		"@melandlabs/ai-rag": "^0.2.11",
 		"@melandlabs/contracts": "workspace:*",
 		"@melandlabs/env-config": "workspace:*",
 		"@melandlabs/okf": "workspace:*",
@@ -50,14 +54,8 @@
 		"xlsx": "^0.18.5",
 		"zod": "^4.3.6"
 	},
-	"peerDependencies": {
-		"@melandlabs/ai-rag": "workspace:*"
-	},
-	"peerDependenciesMeta": {
-		"@melandlabs/ai-rag": {
-			"optional": true
-		}
-	},
+	"peerDependencies": {},
+	"peerDependenciesMeta": {},
 	"devDependencies": {
 		"@melandlabs/ai-rag": "workspace:*",
 		"@melandlabs/config": "workspace:*",


### PR DESCRIPTION
## What

- Adds `"bin": { "workspace": "./dist/cli.js" }` to `@melandlabs/workspace`.
- Promotes `@melandlabs/ai-rag` from optional peerDep to a real dep.
- Bumps `@melandlabs/workspace` to 0.2.0 and `@melandlabs/opencontext` to 0.10.0.

## Why

`workspace/dist/cli.js` already supports being invoked directly (the `isDirectInvocation` guard in `src/cli.ts:499-503` calls `main()` when `import.meta.url === file://${process.argv[1]}`), but the package had no `bin` field, so `pnpm dlx @melandlabs/workspace` returned `ERR_PNPM_DLX_NO_BIN`. With this PR, `pnpm dlx @melandlabs/workspace@0.2.0 update --workspace-id proj-1 --path ~/notes/wiki` works as a one-liner.

`@melandlabs/ai-rag` was previously declared as an optional peerDep. The cross-file strategy calls `generateEmbedding` (via `searchWorkspaceContext`), so on a standalone install of `@melandlabs/workspace` it failed with `Cannot find package '@melandlabs/ai-rag'`. Promoting it to a real dep (and bumping the opencontext dep range to `^0.2.0`) makes the standalone bin work end-to-end.

## Verification

After merge + release:

- `pnpm dlx @melandlabs/workspace@0.2.0 --help` prints the full subcommand help (no `ERR_PNPM_DLX_NO_BIN`).
- `pnpm dlx @melandlabs/workspace@0.2.0 update --workspace-id demo --path ./wiki --db-path ./store.db` indexes all 6 files (`.md` / `.pdf` / `.docx` / `.xlsx`).
- Cross-file search resolves `@melandlabs/ai-rag` cleanly.